### PR TITLE
Add an internal observer as an option

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - all
+
+# Don't build any extra formats
+formats: []

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,17 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
 
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - all
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
 
-# Don't build any extra formats
-formats: []
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,6 +1,0 @@
-name: DIRTY
-
-dependencies:
-    - sphinx_rtd_theme
-#   - pip:
-#       - dependency_from_pip

--- a/DIRTY/calc_photon_trajectory.cpp
+++ b/DIRTY/calc_photon_trajectory.cpp
@@ -1,8 +1,8 @@
 // ======================================================================
 //   Function to calculate the trajectory of a photon.  The stopping
-// point is either reaching the target optical depth (target_tau) or 
+// point is either reaching the target optical depth (target_tau) or
 // reaching the edge of the distribution (marked by negative optical
-// depth between (0 and, but not including -1: integer negative 
+// depth between (0 and, but not including -1: integer negative
 // optical depths denote subgrid indexes.
 //
 // This function returns the distance traveled.
@@ -17,11 +17,13 @@
 double calc_photon_trajectory (photon_data& photon,
 			       geometry_struct& geometry,
 			       double target_tau,
+			       double target_dist,
 			       int& escape,
 			       double& tau_traveled)
 
 {
   double tau_left = target_tau;  // reduce till zero = done
+  double dist_left = target_dist;  // reduce till zero = done
 #ifdef DEBUG_CPT
   if (photon.number == OUTNUM) {
     cout << "oooooooooooooooooooooooooooooooooo" << endl;
@@ -37,7 +39,7 @@ double calc_photon_trajectory (photon_data& photon,
   // move through the grid until escaping or reaching the target tau
   //   need to also handle the case where the photon starts several subgrids down
   //   multiple calls to calc_photon_trajectory needed
-  while ((tau_left > ROUNDOFF_ERR_TRIG) && (!escape)) {
+  while ((tau_left > ROUNDOFF_ERR_TRIG) && (dist_left > ROUNDOFF_ERR_TRIG) && (!escape)) {
 
 #ifdef DEBUG_CPT
     if (photon.number == OUTNUM) {
@@ -51,16 +53,17 @@ double calc_photon_trajectory (photon_data& photon,
       cout << photon.num_current_grids << endl;
     }
 #endif
-    delta_dist = calc_delta_dist(photon, geometry, tau_left, escape, delta_tau);
+    delta_dist = calc_delta_dist(photon, geometry, tau_left, dist_left, escape, delta_tau);
 #ifdef PHOTON_POS
     int i = 0;
     for (i = 0; i < 3; i++)
       cout << photon.position[i] << " ";
     cout << endl;
-#endif    
+#endif
     tau_traveled += delta_tau;
     tau_left -= delta_tau;
     distance_traveled += delta_dist;
+    dist_left -= delta_dist;
 #ifdef DEBUG_CPT
     if (photon.number == OUTNUM) {
       cout << "cpt: photon.path_cur_cells = " << photon.path_cur_cells << endl;

--- a/DIRTY/classify_scattered_photon.cpp
+++ b/DIRTY/classify_scattered_photon.cpp
@@ -132,8 +132,7 @@ void classify_scattered_photon(output_struct& output, photon_data& photon,
         if ((dir_obs_to_scat[1] / sin(theta)) < 0.) phi *= -1.0;
 
         image_indxs[0] = int(output.image_size[0] * ((phi + M_PI) / (2.0 * M_PI)));
-        image_indxs[1] =
-            int(output.image_size[1] * ((dir_obs_to_scat[2] + 1.) / 2.0));
+        image_indxs[1] = int(output.image_size[1] * (1. - dir_obs_to_scat[2]) / 2.0);
       }
 
 #ifdef DEBUG_CSCP

--- a/DIRTY/classify_scattered_photon.cpp
+++ b/DIRTY/classify_scattered_photon.cpp
@@ -3,19 +3,20 @@
 // and global totals.
 //
 // 2006 Apr/KDG - written
-// 2007 Dec/KDG - changed denominator of atan from d-z to d 
+// 2007 Dec/KDG - changed denominator of atan from d-z to d
 // 2008 Mar/KDG - added output for emission/grain types
-// 2008 May/KDG - changed denominator of atan from d to d-z (see fix in setup_dust_grid_slab.cpp)
-// 2008 Jul/KDG - fixed scattered photon weight in the case of subgrids (set current_grid_num = 0)
+// 2008 May/KDG - changed denominator of atan from d to d-z (see fix in
+// setup_dust_grid_slab.cpp)
+// 2008 Jul/KDG - fixed scattered photon weight in the case of subgrids (set
+// current_grid_num = 0)
 // ======================================================================
 #include "classify_scattered_photon.h"
-//#define OUTNUM 25994
-//#define DEBUG_CSCP
+// #define OUTNUM 25994
+// #define DEBUG_CSCP
 
-void classify_scattered_photon (output_struct& output,
-				photon_data& photon,
-				geometry_struct& geometry,
-				runinfo_struct& runinfo)
+void classify_scattered_photon(output_struct& output, photon_data& photon,
+                               geometry_struct& geometry,
+                               runinfo_struct& runinfo)
 
 {
 #ifdef DEBUG_CSCP
@@ -24,107 +25,147 @@ void classify_scattered_photon (output_struct& output,
   }
 #endif
 
-  int i,k;
+  int i, k;
   photon_data tmp_photon;
   double save_scat_weight = 0.0;
   int image_indxs[2];
 
   // loop over the line-of-sights or albedos or whatever
   for (i = 0; i < output.num_outputs; i++) {
-
 #ifdef DEBUG_CSCP
-  if (photon.number == OUTNUM) {
-    cout << "output # = " << i << endl;
-  }
+    if (photon.number == OUTNUM) {
+      cout << "output # = " << i << endl;
+    }
 #endif
     // setup so the hard stuff is not recomputed for the case where there are
     // multiple outputs, but only 1 observer position
     if ((i == 0) || (geometry.num_observers > 1)) {
-
       // copy input photon into temporary photon to ensure no change
       tmp_photon = photon;
 
-      // set the current grid number back to zero to ensure the full tracking can happen
-      // has to start in the base grid!  
+      // set the current grid number back to zero to ensure the full tracking
+      // can happen has to start in the base grid!
       tmp_photon.current_grid_num = 0;
 
 #ifdef DEBUG_CSCP
       if (photon.number == OUTNUM) {
-	cout << "starting scat_weight..." << endl;
+        cout << "starting scat_weight..." << endl;
       }
 #endif
-      // determine the probability the photon would have scattered to the observer
-      tmp_photon.scat_weight = scattered_weight_towards_observer(tmp_photon, geometry, 
-								 output.outputs[i].observer_position);
+      // determine the probability the photon would have scattered to the
+      // observer
+      tmp_photon.scat_weight = scattered_weight_towards_observer(
+          tmp_photon, geometry, output.outputs[i].observer_position);
 #ifdef DEBUG_CSCP
       if (photon.number == OUTNUM) {
-	cout << "starting rotate..." << endl;
+        cout << "starting rotate..." << endl;
       }
 #endif
-      // transform photon positions so that the line-of-sight is along the z-axis 
-      rotate_zaxis_for_observer(output.outputs[i].rotate_transform,tmp_photon);
+      if (geometry.internal_observer == 0) {
+        // external observer case
+        // transform photon positions so that the line-of-sight is along the
+        // z-axis
+        rotate_zaxis_for_observer(output.outputs[i].rotate_transform,
+                                  tmp_photon);
 
-      // take into account the albedo for this scattering
-      tmp_photon.scat_weight *= geometry.albedo;
+        // take into account the albedo for this scattering
+        tmp_photon.scat_weight *= geometry.albedo;
 
-      // save the scattered weight for use when different outputs are for emission/grain types
-      save_scat_weight = tmp_photon.scat_weight;
+        // save the scattered weight for use when different outputs are for
+        // emission/grain types
+        save_scat_weight = tmp_photon.scat_weight;
 
-      // compute x,y angles and image indexs
-      double angle;
-      for (k = 0; k < 2; k++) {
-	angle = atan(tmp_photon.position[k]/(geometry.distance - tmp_photon.position[2]));
-	image_indxs[k] = int((1.0 + (angle/geometry.angular_radius))*output.image_size[k]*0.5);
-// 	image_indxs[k] = int((1.0 + (tmp_photon.position[k]/(1.1*geometry.radius)))*output.image_size[k]*0.5);
-	// check the index is on the image
-	if ((image_indxs[k] < 0) || (image_indxs[k] > (output.image_size[k]-1))) {
-	  cout << "classify_scattered_photon: image_indxs[" << k << "] = " << image_indxs[k] << 
-	    " (beyond image bounds)" << endl;
-	  cout << "real version of index = " << (1.0 + (angle/geometry.angular_radius))*output.image_size[k]*0.5 << endl;
-	  cout << "position = " << tmp_photon.position[k] << endl;
-	  cout << "angle = " << angle << endl;
-	  cout << "model angular radius = " << geometry.angular_radius << endl;
-	  cout << "k = " << k << endl;
-	  cout << "image_size[i] = " << output.image_size[k] << endl;
-	  cout << "photon # = " << photon.number << endl;
-	  int m = 0;
-	  cout << "tmp_photon.position[] = ";
-	  for (m = 0; m < 3; m++)
-	    cout << tmp_photon.position[m] << " ";
-	  cout << endl;
-	  cout << "geometry.distance = " << geometry.distance << endl;
-	  //cout << "updated model angular radius = " << updated_angular_radius << endl;
-	  exit(8);
-	}
+        // compute x,y angles and image indexs
+        double angle;
+        for (k = 0; k < 2; k++) {
+          angle = atan(tmp_photon.position[k] /
+                       (geometry.distance - tmp_photon.position[2]));
+          image_indxs[k] = int((1.0 + (angle / geometry.angular_radius)) *
+                               output.image_size[k] * 0.5);
+          // 	image_indxs[k] = int((1.0 +
+          // (tmp_photon.position[k]/(1.1*geometry.radius)))*output.image_size[k]*0.5);
+          // check the index is on the image
+          if ((image_indxs[k] < 0) ||
+              (image_indxs[k] > (output.image_size[k] - 1))) {
+            cout << "classify_scattered_photon: image_indxs[" << k
+                 << "] = " << image_indxs[k] << " (beyond image bounds)"
+                 << endl;
+            cout << "real version of index = "
+                 << (1.0 + (angle / geometry.angular_radius)) *
+                        output.image_size[k] * 0.5
+                 << endl;
+            cout << "position = " << tmp_photon.position[k] << endl;
+            cout << "angle = " << angle << endl;
+            cout << "model angular radius = " << geometry.angular_radius
+                 << endl;
+            cout << "k = " << k << endl;
+            cout << "image_size[i] = " << output.image_size[k] << endl;
+            cout << "photon # = " << photon.number << endl;
+            int m = 0;
+            cout << "tmp_photon.position[] = ";
+            for (m = 0; m < 3; m++) cout << tmp_photon.position[m] << " ";
+            cout << endl;
+            cout << "geometry.distance = " << geometry.distance << endl;
+            // cout << "updated model angular radius = " <<
+            // updated_angular_radius
+            // << endl;
+            exit(8);
+          }
+        }
+     } else {
+        // internal observer case
+        double obs_to_scat[3];
+        double dist_obs_to_scat = 0.0;
+        double dir_obs_to_scat[3];
+        int k;
+        for (k = 0; k < 3; k++) {
+          obs_to_scat[k] =
+              output.outputs[i].observer_position[k] - tmp_photon.position[k];
+          dist_obs_to_scat += pow(obs_to_scat[k], 2);
+        }
+        dist_obs_to_scat = sqrt(dist_obs_to_scat);
+        for (k = 0; k < 3; k++)
+          dir_obs_to_scat[k] = obs_to_scat[k] / dist_obs_to_scat;
+
+        double theta = acos(dir_obs_to_scat[2]);
+        double phi = acos(dir_obs_to_scat[0] / sin(theta));
+        if ((dir_obs_to_scat[1] / sin(theta)) < 0.) phi *= -1.0;
+
+        image_indxs[0] = int(output.image_size[0] * ((phi + M_PI) / (2.0 * M_PI)));
+        image_indxs[1] =
+            int(output.image_size[1] * ((dir_obs_to_scat[2] + 1.) / 2.0));
       }
 
 #ifdef DEBUG_CSCP
-  if (photon.number == OUTNUM) {
-      cout << "scattered x,y positions = (" << tmp_photon.position[0] << "," << tmp_photon.position[1] << ")" << endl;
-      cout << "model radius = " << geometry.radius << endl;
-      cout << "scattered photon image indexs = (" << image_indxs[0] << "," << image_indxs[1] << ")" << endl;
-  }
+      if (photon.number == OUTNUM) {
+        cout << "scattered x,y positions = (" << tmp_photon.position[0] << ","
+             << tmp_photon.position[1] << ")" << endl;
+        cout << "model radius = " << geometry.radius << endl;
+        cout << "scattered photon image indexs = (" << image_indxs[0] << ","
+             << image_indxs[1] << ")" << endl;
+      }
 #endif
     } else {
       // reset the scattered weight for emission/grain output
       tmp_photon.scat_weight = save_scat_weight;
     }
 
-    // modify weight by probability the emission was due to a specific grain/emission type
-    // only used for dust emission part of dirty
+    // modify weight by probability the emission was due to a specific
+    // grain/emission type only used for dust emission part of dirty
     if (runinfo.dust_thermal_emission && runinfo.do_emission_grain && (i > 0))
       tmp_photon.scat_weight *= tmp_photon.birth_photon_type_prob[i];
 
     // update global values
     output.outputs[i].total_num_scattered_photons += 1.0;
     output.outputs[i].total_scattered_weight += tmp_photon.scat_weight;
-    output.outputs[i].total_scattered_weight_x2 += pow(tmp_photon.scat_weight,2.);
+    output.outputs[i].total_scattered_weight_x2 +=
+        pow(tmp_photon.scat_weight, 2.);
 
     // update the image values
-    output.outputs[i].num_photons_xy(image_indxs[0],image_indxs[1]) += 1.0;
-    output.outputs[i].scattered_weight_xy(image_indxs[0],image_indxs[1]) += tmp_photon.scat_weight;
-    output.outputs[i].scattered_weight_xy_x2(image_indxs[0],image_indxs[1]) += pow(tmp_photon.scat_weight,2.0);
-
+    output.outputs[i].num_photons_xy(image_indxs[0], image_indxs[1]) += 1.0;
+    output.outputs[i].scattered_weight_xy(image_indxs[0], image_indxs[1]) +=
+        tmp_photon.scat_weight;
+    output.outputs[i].scattered_weight_xy_x2(image_indxs[0], image_indxs[1]) +=
+        pow(tmp_photon.scat_weight, 2.0);
   }
-
 }

--- a/DIRTY/classify_stellar_photon.cpp
+++ b/DIRTY/classify_stellar_photon.cpp
@@ -4,20 +4,19 @@
 //
 // 2005 May/KDG - written
 // 2006 Apr/KDG - updated to include rotate_zaxis_for_observe
-// 2007 Feb/KDG - added calcuations of stellar weight (correct for observer position)
-// 2007 Dec/KDG - changed denominator of atan from d-z to d 
-// 2008 Mar/KDG - added output for emission/grain types
-// 2008 May/KDG - changed denominator of atan from d to d-z (see fix in setup_dust_grid_slab.cpp)
+// 2007 Feb/KDG - added calcuations of stellar weight (correct for observer
+// position)
+// 2007 Dec/KDG - changed denominator of atan from d-z to d
+// 2008 Mar/KDG - added output for emission/grain types 2008 May/KDG - changed
+// denominator of atan from d to d-z (see fix in setup_dust_grid_slab.cpp)
 // ======================================================================
 #include "classify_stellar_photon.h"
-//#define DEBUG_CSP
-//#define OUTNUM 0
+// #define DEBUG_CSP
+// #define OUTNUM 0
 
-void classify_stellar_photon (output_struct& output,
-			      photon_data& photon,
-			      geometry_struct& geometry,
-			      runinfo_struct& runinfo,
-			      random_dirty& random_obj)
+void classify_stellar_photon(output_struct& output, photon_data& photon,
+                             geometry_struct& geometry, runinfo_struct& runinfo,
+                             random_dirty& random_obj)
 
 {
   int i;
@@ -34,22 +33,20 @@ void classify_stellar_photon (output_struct& output,
 
   // loop over the line-of-sights or albedos or whatever
   for (i = 0; i < output.num_outputs; i++) {
-
     // setup so the hard stuff is not recomputed for the case where there are
     // multiple outputs, but only 1 observer position
     if ((i == 0) || (geometry.num_observers > 1)) {
-
       // copy input photon into temporary photon to ensure no change
       tmp_photon = photon;
 
       // copy the photon birth position to the position location
       int k;
       for (k = 0; k < 3; k++) {
-	tmp_photon.position[k] = tmp_photon.birth_position[k];
+        tmp_photon.position[k] = tmp_photon.birth_position[k];
 #ifdef DEBUG_CSP
-	if (photon.number == OUTNUM) {
-	  cout << "pos; k = " << k << " " << tmp_photon.position[k] << endl;
-	}
+        if (photon.number == OUTNUM) {
+          cout << "pos; k = " << k << " " << tmp_photon.position[k] << endl;
+        }
 #endif
       }
 
@@ -58,97 +55,149 @@ void classify_stellar_photon (output_struct& output,
 
 #ifdef DEBUG_CSP
       if (photon.number == OUTNUM) {
-	cout << "photon number = " << photon.number << endl;
-	cout << "classify_stellar_photon: in stellar_weight = " << tmp_photon.stellar_weight << endl;
+        cout << "photon number = " << photon.number << endl;
+        cout << "classify_stellar_photon: in stellar_weight = "
+             << tmp_photon.stellar_weight << endl;
       }
 #endif
 
-      // if averging over the entire 4pi steradians is desired, randomize the observer position
-      if (geometry.randomize_observer) {
-  	geometry.observer_angles[0][i] = acos(2.0*random_obj.random_num() - 1.0);
-  	geometry.observer_angles[1][i] = M_PI*(2.0*random_obj.random_num() - 1.0);
+      if (geometry.internal_observer == 0) {
+        // if averging over the entire 4pi steradians is desired, randomize the
+        // observer position
+        if (geometry.randomize_observer) {
+          geometry.observer_angles[0][i] =
+              acos(2.0 * random_obj.random_num() - 1.0);
+          geometry.observer_angles[1][i] =
+              M_PI * (2.0 * random_obj.random_num() - 1.0);
 
- 	compute_observer_trans_matrix(output, geometry, i);
+          compute_observer_trans_matrix(output, geometry, i);
+        }
+      } else {  // internal observer
+        for (int k = 0; k < 3; k++)
+          output.outputs[i].observer_position[k] =
+              geometry.observer_position[k];
       }
-
       // determine stellar weight towards observer
-      tmp_photon.stellar_weight = stellar_weight_towards_observer(tmp_photon, geometry,
-								  output.outputs[i].observer_position);
+      tmp_photon.stellar_weight = stellar_weight_towards_observer(
+          tmp_photon, geometry, output.outputs[i].observer_position);
 
-      // save the stellar weight for use when different outputs are for emission/grain types
+      // save the stellar weight for use when different outputs are for
+      // emission/grain types
       save_stellar_weight = tmp_photon.stellar_weight;
 
-#ifdef DEBUG_CSP 
+#ifdef DEBUG_CSP
       if (photon.number == OUTNUM) {
-	cout << "photon.first.tau = " << tmp_photon.first_tau << endl;
-	cout << "classify_stellar_photon: stellar_weight = " << tmp_photon.stellar_weight << endl;
+        cout << "photon.first.tau = " << tmp_photon.first_tau << endl;
+        cout << "classify_stellar_photon: stellar_weight = "
+             << tmp_photon.stellar_weight << endl;
       }
 #endif
 
-      // transform photon positions so that the line-of-sight is along 
-      // the z-axis 
-      rotate_zaxis_for_observer(output.outputs[i].rotate_transform,tmp_photon);
+      if (geometry.internal_observer == 0) {
+        // external observer case
+        // transform photon positions so that the line-of-sight is along
+        // the z-axis
+        rotate_zaxis_for_observer(output.outputs[i].rotate_transform,
+                                  tmp_photon);
 
-      // compute x,y angles and image indexs
-      double angle;
-      for (k = 0; k < 2; k++) {
-   	angle = atan(tmp_photon.position[k]/(geometry.distance - tmp_photon.position[2]));
-  	image_indxs[k] = int((1.0 + (angle/geometry.angular_radius))*output.image_size[k]*0.5);
-// 	image_indxs[k] = int((1.0 + (tmp_photon.birth_position[k]/(1.1*geometry.radius)))*output.image_size[k]*0.5);
-	// check the index is on the image
-	if ((image_indxs[k] < 0) || (image_indxs[k] > (output.image_size[k]-1))) {
-	  cout << "classify stellar photon: image_indxs[" << k << "] = " << image_indxs[k] << 
-	    " (beyond image bounds)" << endl;
-	  cout << "real version of index = " << (1.0 + (angle/geometry.angular_radius))*output.image_size[k]*0.5 << endl;
-	  exit(8);
-	}
+        // compute x,y angles and image indexs
+        double angle;
+        for (k = 0; k < 2; k++) {
+          angle = atan(tmp_photon.position[k] /
+                       (geometry.distance - tmp_photon.position[2]));
+          image_indxs[k] = int((1.0 + (angle / geometry.angular_radius)) *
+                               output.image_size[k] * 0.5);
+          // 	image_indxs[k] = int((1.0 +
+          // (tmp_photon.birth_position[k]/(1.1*geometry.radius)))*output.image_size[k]*0.5);
+          // check the index is on the image
+          if ((image_indxs[k] < 0) ||
+              (image_indxs[k] > (output.image_size[k] - 1))) {
+            cout << "classify stellar photon: image_indxs[" << k
+                 << "] = " << image_indxs[k] << " (beyond image bounds)"
+                 << endl;
+            cout << "real version of index = "
+                 << (1.0 + (angle / geometry.angular_radius)) *
+                        output.image_size[k] * 0.5
+                 << endl;
+            exit(8);
+          }
+        }
+      } else {
+        // internal observer case
+        // can use the photon direction cosines as they give the reverse
+        // direction of what is needed
+        double obs_to_birth[3];
+        double dist_obs_to_birth = 0.0;
+        double dir_obs_to_birth[3];
+        int k;
+        for (k = 0; k < 3; k++) {
+          obs_to_birth[k] =
+              output.outputs[i].observer_position[k] - tmp_photon.position[k];
+          dist_obs_to_birth += pow(obs_to_birth[k], 2);
+        }
+        dist_obs_to_birth = sqrt(dist_obs_to_birth);
+        for (k = 0; k < 3; k++)
+          dir_obs_to_birth[k] = obs_to_birth[k] / dist_obs_to_birth;
+
+        double theta = acos(dir_obs_to_birth[2]);
+        double phi = acos(dir_obs_to_birth[0] / sin(theta));
+
+        image_indxs[0] = int(output.image_size[0] * (phi / (2.0 * M_PI)));
+        image_indxs[1] =
+            int(output.image_size[1] * ((dir_obs_to_birth[2] + 1.) / 2.0));
       }
 #ifdef DEBUG_CSP
       if (photon.number == OUTNUM) {
-	cout << "geometry.distance = " << geometry.distance << endl;
-	cout << "stellar x,y positions = (" << tmp_photon.position[0] << "," << tmp_photon.position[1] << ")" << endl;
-	cout << "model radius = " << geometry.radius << endl;
-	cout << "stellar photon image indexs = (" << image_indxs[0] << "," << image_indxs[1] << ")" << endl;
+        cout << "geometry.distance = " << geometry.distance << endl;
+        cout << "stellar x,y positions = (" << tmp_photon.position[0] << ","
+             << tmp_photon.position[1] << ")" << endl;
+        cout << "model radius = " << geometry.radius << endl;
+        cout << "stellar photon image indexs = (" << image_indxs[0] << ","
+             << image_indxs[1] << ")" << endl;
       }
 #endif
+
     } else {
       // reset the stellar weight for emission/grain output
       tmp_photon.stellar_weight = save_stellar_weight;
     }
 
-    // modify weight by probability the emission was due to a specific grain/emission type
-    // only used for dust emission part of dirty
+    // modify weight by probability the emission was due to a specific
+    // grain/emission type only used for dust emission part of dirty
     if (runinfo.dust_thermal_emission && runinfo.do_emission_grain && (i > 0))
       tmp_photon.stellar_weight *= tmp_photon.birth_photon_type_prob[i];
 
 #ifdef DEBUG_CSP
-      if (photon.number == OUTNUM) {
-	cout << "tmp_photon.stellar_weight = " << tmp_photon.stellar_weight << endl;
-	cout << "stellar_weight (before) = " << output.outputs[i].total_stellar_weight << endl;
-	cout << "i = " << i << endl;
-      }
+    if (photon.number == OUTNUM) {
+      cout << "tmp_photon.stellar_weight = " << tmp_photon.stellar_weight
+           << endl;
+      cout << "stellar_weight (before) = "
+           << output.outputs[i].total_stellar_weight << endl;
+      cout << "i = " << i << endl;
+    }
 #endif
-      // update global values
-      output.outputs[i].total_num_photons += 1.0;
-      output.outputs[i].total_stellar_weight += tmp_photon.stellar_weight;
-      output.outputs[i].total_stellar_weight_x2 += pow(tmp_photon.stellar_weight,2.);
-      
-      output.outputs[i].ave_first_tau += tmp_photon.first_tau;
-      output.outputs[i].ave_first_tau_x2 += pow(tmp_photon.first_tau,2.);
-      
-      // update the image values
-      output.outputs[i].num_stellar_photons_xy(image_indxs[0],image_indxs[1]) += 1.0;
-      output.outputs[i].stellar_weight_xy(image_indxs[0],image_indxs[1]) += tmp_photon.stellar_weight;
-      output.outputs[i].stellar_weight_xy_x2(image_indxs[0],image_indxs[1]) += pow(tmp_photon.stellar_weight,2.0);
-      
-      //     cout << "stellar_weight (after) = " << tmp_photon.stellar_weight << " ";
-      //     cout << "first_tau = " << tmp_photon.first_tau << endl;
+    // update global values
+    output.outputs[i].total_num_photons += 1.0;
+    output.outputs[i].total_stellar_weight += tmp_photon.stellar_weight;
+    output.outputs[i].total_stellar_weight_x2 +=
+        pow(tmp_photon.stellar_weight, 2.);
+
+    output.outputs[i].ave_first_tau += tmp_photon.first_tau;
+    output.outputs[i].ave_first_tau_x2 += pow(tmp_photon.first_tau, 2.);
+
+    // update the image values
+    output.outputs[i].num_stellar_photons_xy(image_indxs[0], image_indxs[1]) +=
+        1.0;
+    output.outputs[i].stellar_weight_xy(image_indxs[0], image_indxs[1]) +=
+        tmp_photon.stellar_weight;
+    output.outputs[i].stellar_weight_xy_x2(image_indxs[0], image_indxs[1]) +=
+        pow(tmp_photon.stellar_weight, 2.0);
+
 #ifdef DEBUG_CSP
-      if (photon.number == OUTNUM) {
-	cout << "stellar_weight (after) = " << output.outputs[i].total_stellar_weight << endl;
-      }
+    if (photon.number == OUTNUM) {
+      cout << "stellar_weight (after) = "
+           << output.outputs[i].total_stellar_weight << endl;
+    }
 #endif
-
   }
-
 }

--- a/DIRTY/classify_stellar_photon.cpp
+++ b/DIRTY/classify_stellar_photon.cpp
@@ -124,8 +124,6 @@ void classify_stellar_photon(output_struct& output, photon_data& photon,
         }
       } else {
         // internal observer case
-        // can use the photon direction cosines as they give the reverse
-        // direction of what is needed
         double obs_to_birth[3];
         double dist_obs_to_birth = 0.0;
         double dir_obs_to_birth[3];
@@ -141,8 +139,9 @@ void classify_stellar_photon(output_struct& output, photon_data& photon,
 
         double theta = acos(dir_obs_to_birth[2]);
         double phi = acos(dir_obs_to_birth[0] / sin(theta));
+        if ((dir_obs_to_birth[1] / sin(theta)) < 0.) phi *= -1.0;
 
-        image_indxs[0] = int(output.image_size[0] * (phi / (2.0 * M_PI)));
+        image_indxs[0] = int(output.image_size[0] * ((phi + M_PI) / (2.0 * M_PI)));
         image_indxs[1] =
             int(output.image_size[1] * ((dir_obs_to_birth[2] + 1.) / 2.0));
       }

--- a/DIRTY/classify_stellar_photon.cpp
+++ b/DIRTY/classify_stellar_photon.cpp
@@ -142,8 +142,7 @@ void classify_stellar_photon(output_struct& output, photon_data& photon,
         if ((dir_obs_to_birth[1] / sin(theta)) < 0.) phi *= -1.0;
 
         image_indxs[0] = int(output.image_size[0] * ((phi + M_PI) / (2.0 * M_PI)));
-        image_indxs[1] =
-            int(output.image_size[1] * ((dir_obs_to_birth[2] + 1.) / 2.0));
+        image_indxs[1] = int(output.image_size[1] * (1. - dir_obs_to_birth[2]) / 2.0);
       }
 #ifdef DEBUG_CSP
       if (photon.number == OUTNUM) {

--- a/DIRTY/compute_observer_trans_matrix.cpp
+++ b/DIRTY/compute_observer_trans_matrix.cpp
@@ -1,5 +1,5 @@
 // ======================================================================
-//   Procedure to compute the transformation/rotation matrix for the 
+//   Procedure to compute the transformation/rotation matrix for the
 // observer.
 //
 // 2008 Jun/KDG - written (taken from initialize_output.cpp)
@@ -17,9 +17,9 @@ void compute_observer_trans_matrix (output_struct& output,
   //   matrix specifically to rotate so the observer position is along the z-axis
   //   if the observer is put at the standard theta,phi location
   //   (need to check this)
-  float theta; 
+  float theta;
   float phi;
-  
+
   if (geometry.num_observers > 1) {
     theta = geometry.observer_angles[0][i];
     phi = geometry.observer_angles[1][i];
@@ -27,46 +27,26 @@ void compute_observer_trans_matrix (output_struct& output,
     theta = geometry.observer_angles[0][0];
     phi = geometry.observer_angles[1][0];
   }
-  
+
 #ifdef DEBUG_COTM
   cout << "observer (theta,phi) = (" << theta*180./M_PI << "," << phi*180./M_PI << ")" << endl;
 #endif
-  
+
   output.outputs[i].rotate_transform[0][0] = cos(theta)*cos(phi);
   output.outputs[i].rotate_transform[0][1] = cos(theta)*sin(phi);
   output.outputs[i].rotate_transform[0][2] = -sin(theta);
-  
+
   output.outputs[i].rotate_transform[1][0] = -sin(phi);
   output.outputs[i].rotate_transform[1][1] = cos(phi);
   output.outputs[i].rotate_transform[1][2] = 0.0;
-  
+
   output.outputs[i].rotate_transform[2][0] = sin(theta)*cos(phi);
   output.outputs[i].rotate_transform[2][1] = sin(theta)*sin(phi);
   output.outputs[i].rotate_transform[2][2] = cos(theta);
-  
-  
-  // attempting to have everything referenced to a source on the x-axis
-  // all angles negative as this transform is setup to rotate the source
-  // onto the z-axis so that the yz postions can be used to find the location
-  // of each photon in the output image
-  // ***doesn't work*** probably need to do the full spherical transformation
-  //   which is what I remember doing previously and is above (which does work!)
-  
-  //     output.outputs[i].rotate_transform[0][0] = cos(-phi)*cos(-theta);
-  //     output.outputs[i].rotate_transform[0][1] = sin(-phi);
-  //     output.outputs[i].rotate_transform[0][2] = cos(-phi)*sin(-theta);
-  
-  //     output.outputs[i].rotate_transform[1][0] = -sin(-phi)*cos(-theta);
-  //     output.outputs[i].rotate_transform[1][1] = cos(-phi);
-  //     output.outputs[i].rotate_transform[1][2] = -sin(-phi)*sin(-theta);
-  
-  //     output.outputs[i].rotate_transform[2][0] = -sin(-theta);
-  //     output.outputs[i].rotate_transform[2][1] = 0.0;
-//     output.outputs[i].rotate_transform[2][2] = cos(-theta);
-  
+
 #ifdef DEBUG_COTM
   int j,k;
-  cout << "transformation matrix for (theta,phi) = "; 
+  cout << "transformation matrix for (theta,phi) = ";
   cout << "(" << theta << "," << phi << ")" << endl;
   for (j = 0; j < 3; j++) {
     for (k = 0; k < 3; k++)
@@ -80,3 +60,22 @@ void compute_observer_trans_matrix (output_struct& output,
   output.outputs[i].observer_position[2] = geometry.distance*cos(theta);
 
 }
+
+// attempting to have everything referenced to a source on the x-axis
+// all angles negative as this transform is setup to rotate the source
+// onto the z-axis so that the yz postions can be used to find the location
+// of each photon in the output image
+// ***doesn't work*** probably need to do the full spherical transformation
+//   which is what I remember doing previously and is above (which does work!)
+
+//     output.outputs[i].rotate_transform[0][0] = cos(-phi)*cos(-theta);
+//     output.outputs[i].rotate_transform[0][1] = sin(-phi);
+//     output.outputs[i].rotate_transform[0][2] = cos(-phi)*sin(-theta);
+
+//     output.outputs[i].rotate_transform[1][0] = -sin(-phi)*cos(-theta);
+//     output.outputs[i].rotate_transform[1][1] = cos(-phi);
+//     output.outputs[i].rotate_transform[1][2] = -sin(-phi)*sin(-theta);
+
+//     output.outputs[i].rotate_transform[2][0] = -sin(-theta);
+//     output.outputs[i].rotate_transform[2][1] = 0.0;
+//     output.outputs[i].rotate_transform[2][2] = cos(-theta);

--- a/DIRTY/get_run_parameters.cpp
+++ b/DIRTY/get_run_parameters.cpp
@@ -6,155 +6,213 @@
 // ======================================================================
 #include "get_run_parameters.h"
 
-void get_run_parameters (ConfigFile& param_data,
-			 output_struct& output,
-			 geometry_struct& geometry,
-			 runinfo_struct& runinfo)
-{
+void get_run_parameters(ConfigFile& param_data, output_struct& output,
+                        geometry_struct& geometry, runinfo_struct& runinfo) {
   // get type of energy grid storing (memory/disk) desired
-//   geometry.abs_energy_storage_type = param_data.IValue("Run","abs_energy_storage");
-//   check_input_param("abs_energy_storage_type",geometry.abs_energy_storage_type,0,1);
+  //   geometry.abs_energy_storage_type =
+  //   param_data.IValue("Run","abs_energy_storage");
+  //   check_input_param("abs_energy_storage_type",geometry.abs_energy_storage_type,0,1);
   // removed possibility to do disk storage when polyc added (KDG - 30 Mar 2009)
-  // leave in the code (where possible) in case we want to use the disk at a later date
+  // leave in the code (where possible) in case we want to use the disk at a
+  // later date
   geometry.abs_energy_storage_type = 0;
 
   // indicate that the absorbed energy grid has not been initialized
   geometry.abs_energy_grid_initialized = 0;
 
-  geometry.n_photons = long(param_data.DValue("Run","num_photons"));
-  check_input_param("num_photons",geometry.n_photons,1,1e10);
+  geometry.n_photons = long(param_data.DValue("Run", "num_photons"));
+  check_input_param("num_photons", geometry.n_photons, 1, 1e10);
 
-  geometry.max_num_scat = long(param_data.IValue("Run","max_num_scat"));
-  if (geometry.max_num_scat == -99) geometry.max_num_scat = MAX_NUM_SCAT;  // set to default
-  check_input_param("max_num_scat",geometry.max_num_scat,1,1000);
+  geometry.max_num_scat = long(param_data.IValue("Run", "max_num_scat"));
+  if (geometry.max_num_scat == -99)
+    geometry.max_num_scat = MAX_NUM_SCAT;  // set to default
+  check_input_param("max_num_scat", geometry.max_num_scat, 1, 1000);
 
-  // fractions for biased scattering (better samples high optical depth scattering)
-  geometry.scat_bias_fraction = param_data.DValue("Run","scat_bias_fraction");
-  if (param_data.isBadFloat(geometry.scat_bias_fraction)) geometry.scat_bias_fraction = 0.5;
-  check_input_param("scat_bias_fraction",geometry.scat_bias_fraction,0.0,1.0);
+  // fractions for biased scattering (better samples high optical depth
+  // scattering)
+  geometry.scat_bias_fraction = param_data.DValue("Run", "scat_bias_fraction");
+  if (param_data.isBadFloat(geometry.scat_bias_fraction))
+    geometry.scat_bias_fraction = 0.5;
+  check_input_param("scat_bias_fraction", geometry.scat_bias_fraction, 0.0,
+                    1.0);
 
-  // fractions for biased angle scattering (better samples back scattered photons for g >> 0)
-  geometry.scat_angle_bias_fraction = param_data.DValue("Run","scat_angle_bias_fraction");
-  if (param_data.isBadFloat(geometry.scat_angle_bias_fraction)) geometry.scat_angle_bias_fraction = 0.0;
-  check_input_param("scat_angle_bias_fraction",geometry.scat_angle_bias_fraction,0.0,1.0);
+  // fractions for biased angle scattering (better samples back scattered
+  // photons for g >> 0)
+  geometry.scat_angle_bias_fraction =
+      param_data.DValue("Run", "scat_angle_bias_fraction");
+  if (param_data.isBadFloat(geometry.scat_angle_bias_fraction))
+    geometry.scat_angle_bias_fraction = 0.0;
+  check_input_param("scat_angle_bias_fraction",
+                    geometry.scat_angle_bias_fraction, 0.0, 1.0);
 
-  // fraction for biased dust emission (better samples cells with low radiation fields)
-  geometry.emit_bias_fraction = param_data.DValue("Run","emit_bias_fraction");
-  if (param_data.isBadFloat(geometry.emit_bias_fraction)) geometry.emit_bias_fraction = 0.5;
-  check_input_param("emit_bias_fraction",geometry.emit_bias_fraction,0.0,1.0);
+  // fraction for biased dust emission (better samples cells with low radiation
+  // fields)
+  geometry.emit_bias_fraction = param_data.DValue("Run", "emit_bias_fraction");
+  if (param_data.isBadFloat(geometry.emit_bias_fraction))
+    geometry.emit_bias_fraction = 0.5;
+  check_input_param("emit_bias_fraction", geometry.emit_bias_fraction, 0.0,
+                    1.0);
 
-  int image_size = param_data.IValue("Run","output_image_size");
-  check_input_param("output_image_size",image_size,1,50000);
-  output.image_size[0] = image_size;
-  output.image_size[1] = image_size;
+  int image_size = param_data.IValue("Run", "output_image_size");
+  if (image_size > 0) {
+    check_input_param("output_image_size", image_size, 1, 50000);
+    output.image_size[0] = image_size;
+    output.image_size[1] = image_size;
+  }
 
-  output.file_base = param_data.SValue("Run","output_filebase");
-  check_input_param("output_filebase",output.file_base,"dirty_test");
+  int image_x_size = param_data.IValue("Run", "output_image_x_size");
+  if (image_x_size > 0) {
+    check_input_param("output_image_x_size", image_x_size, 1, 50000);
+    output.image_size[0] = image_x_size;
+  }
+  int image_y_size = param_data.IValue("Run", "output_image_y_size");
+  if (image_y_size > 0) {
+    check_input_param("output_image_y_size", image_y_size, 1, 50000);
+    output.image_size[1] = image_y_size;
+  }
 
-  output.do_output_model_grid = param_data.IValue("Run","output_model_grid");
-  if (output.do_output_model_grid == -99) output.do_output_model_grid = 0;  // set to no output if not initially set
-  check_input_param("output_model_grid",output.do_output_model_grid,0,1);
+  if ((image_size < 0) && (image_x_size < 0) && (image_y_size < 0)) {
+    cout << "either image_size or (image_x_size, image_y_size) need to be set." << endl;
+    exit(8);
+  }
 
-  // setup the emission_type string (added to file_base later) to be "" for stellar
+  output.file_base = param_data.SValue("Run", "output_filebase");
+  check_input_param("output_filebase", output.file_base, "dirty_test");
+
+  output.do_output_model_grid = param_data.IValue("Run", "output_model_grid");
+  if (output.do_output_model_grid == -99)
+    output.do_output_model_grid = 0;  // set to no output if not initially set
+  check_input_param("output_model_grid", output.do_output_model_grid, 0, 1);
+
+  // setup the emission_type string (added to file_base later) to be "" for
+  // stellar
   output.emission_type = "";
 
-  output.type = param_data.SValue("Run","output_type");
-  check_input_param("output_filebase",output.type,"ratio");
+  output.type = param_data.SValue("Run", "output_type");
+  check_input_param("output_filebase", output.type, "ratio");
 
-  runinfo.verbose = param_data.IValue("Run","verbose");
-  if (runinfo.verbose == -99) runinfo.verbose = 0;  // set to no output if not initially set
-  check_input_param("verbose",runinfo.verbose,0,2);
+  runinfo.verbose = param_data.IValue("Run", "verbose");
+  if (runinfo.verbose == -99)
+    runinfo.verbose = 0;  // set to no output if not initially set
+  check_input_param("verbose", runinfo.verbose, 0, 2);
 
-  runinfo.do_ere_emission = param_data.IValue("Run","do_ere_emission");
-  if (runinfo.do_ere_emission == -99) runinfo.do_ere_emission = 0;  // set to no if not initially set
-  check_input_param("do_ere_emission",runinfo.do_ere_emission,0,1);
+  runinfo.do_ere_emission = param_data.IValue("Run", "do_ere_emission");
+  if (runinfo.do_ere_emission == -99)
+    runinfo.do_ere_emission = 0;  // set to no if not initially set
+  check_input_param("do_ere_emission", runinfo.do_ere_emission, 0, 1);
 
   if (runinfo.do_ere_emission) {  // get the ERE parameters
-    runinfo.ere_efficiency = param_data.FValue("Extended Red Emission","ere_efficiency");
-    check_input_param("ere_efficiency",runinfo.ere_efficiency,0.0,1.0);
+    runinfo.ere_efficiency =
+        param_data.FValue("Extended Red Emission", "ere_efficiency");
+    check_input_param("ere_efficiency", runinfo.ere_efficiency, 0.0, 1.0);
 
-    runinfo.ere_excitation_wavelength = param_data.FValue("Extended Red Emission","ere_excitation_wavelength");
-    check_input_param("ere_excitation_wavelength",runinfo.ere_excitation_wavelength,0.01,1.0);
+    runinfo.ere_excitation_wavelength =
+        param_data.FValue("Extended Red Emission", "ere_excitation_wavelength");
+    check_input_param("ere_excitation_wavelength",
+                      runinfo.ere_excitation_wavelength, 0.01, 1.0);
     runinfo.ere_excitation_wavelength *= Constant::UM_CM;
 
-    runinfo.ere_peak_wavelength = param_data.FValue("Extended Red Emission","ere_peak_wavelength");
-    check_input_param("ere_peak_wavelength",runinfo.ere_peak_wavelength,0.3,1.0);
+    runinfo.ere_peak_wavelength =
+        param_data.FValue("Extended Red Emission", "ere_peak_wavelength");
+    check_input_param("ere_peak_wavelength", runinfo.ere_peak_wavelength, 0.3,
+                      1.0);
     runinfo.ere_peak_wavelength *= Constant::UM_CM;
 
-    runinfo.ere_fwhm = param_data.FValue("Extended Red Emission","ere_fwhm");
-    check_input_param("ere_fwhm",runinfo.ere_fwhm,0.01,0.3);
+    runinfo.ere_fwhm = param_data.FValue("Extended Red Emission", "ere_fwhm");
+    check_input_param("ere_fwhm", runinfo.ere_fwhm, 0.01, 0.3);
     runinfo.ere_fwhm *= Constant::UM_CM;
   }
 
-  runinfo.do_dust_emission = param_data.IValue("Run","do_dust_emission");
-  if (runinfo.do_dust_emission == -99) runinfo.do_dust_emission = 0;  // set to no if not initially set
-  check_input_param("do_dust_emission",runinfo.do_dust_emission,0,1);
+  runinfo.do_dust_emission = param_data.IValue("Run", "do_dust_emission");
+  if (runinfo.do_dust_emission == -99)
+    runinfo.do_dust_emission = 0;  // set to no if not initially set
+  check_input_param("do_dust_emission", runinfo.do_dust_emission, 0, 1);
 
-  runinfo.do_stochastic_dust_emission = param_data.IValue("Run","do_stochastic_dust_emission");
-  if (runinfo.do_stochastic_dust_emission == -99) runinfo.do_stochastic_dust_emission = 0;  // set to no if not initially set
-  check_input_param("do_stochastic_dust_emission",runinfo.do_stochastic_dust_emission,0,1);
+  runinfo.do_stochastic_dust_emission =
+      param_data.IValue("Run", "do_stochastic_dust_emission");
+  if (runinfo.do_stochastic_dust_emission == -99)
+    runinfo.do_stochastic_dust_emission = 0;  // set to no if not initially set
+  check_input_param("do_stochastic_dust_emission",
+                    runinfo.do_stochastic_dust_emission, 0, 1);
 
-  runinfo.do_emission_grain = param_data.IValue("Run","do_emission_grain");
-  if (runinfo.do_emission_grain == -99) runinfo.do_emission_grain = 0;  // set to no if not initially set
-  check_input_param("do_emission_grain",runinfo.do_emission_grain,0,1);
+  runinfo.do_emission_grain = param_data.IValue("Run", "do_emission_grain");
+  if (runinfo.do_emission_grain == -99)
+    runinfo.do_emission_grain = 0;  // set to no if not initially set
+  check_input_param("do_emission_grain", runinfo.do_emission_grain, 0, 1);
 
   if (runinfo.do_dust_emission) {
     // now see what energy conservation is required
-    runinfo.energy_conserve_target = param_data.FValue("Run","energy_conserve_target");
-    check_input_param("energy_conserve_target",runinfo.energy_conserve_target,0.,1.);
+    runinfo.energy_conserve_target =
+        param_data.FValue("Run", "energy_conserve_target");
+    check_input_param("energy_conserve_target", runinfo.energy_conserve_target,
+                      0., 1.);
 
-    runinfo.energy_conserve_target2 = param_data.FValue("Run","energy_conserve_target2");
-    if (param_data.isBadFloat(runinfo.energy_conserve_target2)) runinfo.energy_conserve_target2 = 0;  // set to zero if not initially set
-    check_input_param("energy_conserve_target2",runinfo.energy_conserve_target2,0.,1.);
+    runinfo.energy_conserve_target2 =
+        param_data.FValue("Run", "energy_conserve_target2");
+    if (param_data.isBadFloat(runinfo.energy_conserve_target2))
+      runinfo.energy_conserve_target2 = 0;  // set to zero if not initially set
+    check_input_param("energy_conserve_target2",
+                      runinfo.energy_conserve_target2, 0., 1.);
   }
-  runinfo.total_emitted_energy = 0.0;  // need to zero out so the first iteration always happens (measurement is a delta)
+  runinfo.total_emitted_energy =
+      0.0;  // need to zero out so the first iteration always happens
+            // (measurement is a delta)
 
   // get the maximum number of iterations allowed (DE+RT)
-  runinfo.iter_max = param_data.IValue("Run","maximum_iterations");
-  if (runinfo.iter_max == -99) runinfo.iter_max = 5;  // set to 5 if not initially set
-  check_input_param("iter_max",runinfo.iter_max,0,100);
+  runinfo.iter_max = param_data.IValue("Run", "maximum_iterations");
+  if (runinfo.iter_max == -99)
+    runinfo.iter_max = 5;  // set to 5 if not initially set
+  check_input_param("iter_max", runinfo.iter_max, 0, 100);
 
   // now see if RT check converged is set
-  runinfo.rt_check_converged = param_data.IValue("Run","rt_check_converged");
-  if (runinfo.rt_check_converged == -99) runinfo.rt_check_converged = 0;  // set to no if not initially set
-  check_input_param("rt_check_converged",runinfo.rt_check_converged,0,1);
+  runinfo.rt_check_converged = param_data.IValue("Run", "rt_check_converged");
+  if (runinfo.rt_check_converged == -99)
+    runinfo.rt_check_converged = 0;  // set to no if not initially set
+  check_input_param("rt_check_converged", runinfo.rt_check_converged, 0, 1);
 
   if (runinfo.rt_check_converged) {
-    runinfo.rt_converge_target = param_data.FValue("Run","rt_converge_target");
-    check_input_param("rt_converge_target",runinfo.rt_converge_target,0.,1.);
+    runinfo.rt_converge_target = param_data.FValue("Run", "rt_converge_target");
+    check_input_param("rt_converge_target", runinfo.rt_converge_target, 0., 1.);
   }
 
   // output info
 
-  runinfo.do_image_output = param_data.IValue("Run","do_image_output");
-  if (runinfo.do_image_output == -99) runinfo.do_image_output = 0;  // set to no if not initially set
-  check_input_param("do_image_output",runinfo.do_image_output,0,1);
+  runinfo.do_image_output = param_data.IValue("Run", "do_image_output");
+  if (runinfo.do_image_output == -99)
+    runinfo.do_image_output = 0;  // set to no if not initially set
+  check_input_param("do_image_output", runinfo.do_image_output, 0, 1);
 
-  runinfo.do_global_output = param_data.IValue("Run","do_global_output");
-  if (runinfo.do_global_output == -99) runinfo.do_global_output = 0;  // set to no if not initially set
-  check_input_param("do_global_output",runinfo.do_global_output,0,1);
+  runinfo.do_global_output = param_data.IValue("Run", "do_global_output");
+  if (runinfo.do_global_output == -99)
+    runinfo.do_global_output = 0;  // set to no if not initially set
+  check_input_param("do_global_output", runinfo.do_global_output, 0, 1);
 
-//   runinfo.global_output_fits = param_data.IValue("Run","global_output_fits");
-//   if (runinfo.global_output_fits == -99) runinfo.global_output_fits = 0;  // set to no if not initially set
-//   check_input_param("global_output_fits",runinfo.global_output_fits,0,1);
+  //   runinfo.global_output_fits =
+  //   param_data.IValue("Run","global_output_fits"); if
+  //   (runinfo.global_output_fits == -99) runinfo.global_output_fits = 0;  //
+  //   set to no if not initially set
+  //   check_input_param("global_output_fits",runinfo.global_output_fits,0,1);
 
   // check that at least one type of output is picked
   if (!runinfo.do_image_output && !runinfo.do_global_output) {
-    cout << "Neither images nor global,multiwavelength output picked = no output!" << endl;
+    cout << "Neither images nor global,multiwavelength output picked = no "
+            "output!"
+         << endl;
     cout << "One or the other is required." << endl;
-    cout << "Add 'do_image_output=1' or 'do_global_output=1' to the 'Run' section of the parameter file." << endl;
+    cout << "Add 'do_image_output=1' or 'do_global_output=1' to the 'Run' "
+            "section of the parameter file."
+         << endl;
     exit(8);
   }
 
   // random seed
-  runinfo.ran_seed = param_data.IValue("Run","random_num_seed");
+  runinfo.ran_seed = param_data.IValue("Run", "random_num_seed");
   if (runinfo.ran_seed == -99) runinfo.ran_seed = long(987654321);  // default
-  check_input_param("random_num_seed",runinfo.ran_seed,0,long(1000000000));
+  check_input_param("random_num_seed", runinfo.ran_seed, 0, long(1000000000));
   runinfo.ran_seed *= -1;
 
   output.arrays_allocated = 0;
   runinfo.dust_thermal_emission = 0;
 
   // Get failure record preferences.
-
 }

--- a/DIRTY/include/calc_delta_dist.h
+++ b/DIRTY/include/calc_delta_dist.h
@@ -13,6 +13,7 @@
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 

--- a/DIRTY/include/calc_photon_trajectory.h
+++ b/DIRTY/include/calc_photon_trajectory.h
@@ -18,6 +18,7 @@ extern void determine_grid_position_index (geometry_struct& geometry,
 extern double calc_delta_dist (photon_data& photon,
 			       geometry_struct& geometry,
 			       double target_tau,
+			       double target_dist,
 			       int& escape,
 			       double& tau_traveled);
 

--- a/DIRTY/include/forced_first_scatter.h
+++ b/DIRTY/include/forced_first_scatter.h
@@ -20,6 +20,7 @@ extern void determine_photon_position_index_initial (geometry_struct& geometry,
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 

--- a/DIRTY/include/geometry_def.h
+++ b/DIRTY/include/geometry_def.h
@@ -1,5 +1,5 @@
 // ======================================================================
-//   Header file for classify stellar photon procedure.  
+//   Header file for classify stellar photon procedure.
 // Include files and function definitions.
 //
 // 2003 Jun/KDG - written
@@ -70,6 +70,9 @@ struct geometry_struct {
   int num_observers;  // number of different observer directions
   float observer_angles[2][MAX_OBSERVERS]; // theta,phi for each observer
 
+  int internal_observer; // 1=yes, 0=no
+  double observer_position[3]; // location of observer in grid
+
   string source_type;   // type of source (stars, diffuse, etc.)
   double total_source_luminosity;  // in ergs s^-1 A^-1
   int new_photon_source_type; // integer to control how to emit photons
@@ -86,7 +89,7 @@ struct geometry_struct {
   int stellar_emit_n_xy;
   vector<double> stellar_emit_xy_vals;
   //  double stellar_emit_constant_xy;
-  
+
   // power sphere variables
   double pow_sphere_exponent;
   double pow_sphere_inner_radius;

--- a/DIRTY/include/new_photon_diffuse_source.h
+++ b/DIRTY/include/new_photon_diffuse_source.h
@@ -18,6 +18,7 @@ extern void determine_photon_position_index_initial (geometry_struct& geometry,
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 

--- a/DIRTY/include/next_scatter.h
+++ b/DIRTY/include/next_scatter.h
@@ -17,6 +17,7 @@
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 #endif

--- a/DIRTY/include/scatter_photon.h
+++ b/DIRTY/include/scatter_photon.h
@@ -15,9 +15,10 @@
 
 // determines the photon trajectory (returns the distance and tau traveled)
 extern double calc_photon_trajectory (photon_data& photon,
-                                      geometry_struct& geometry,
-                                      double target_tau,
-                                      int& escape,
-                                      double& tau_traveled);
+				      geometry_struct& geometry,
+				      double target_tau,
+				      double target_dist,
+				      int& escape,
+				      double& tau_traveled);
 
 #endif

--- a/DIRTY/include/scattered_weight_towards_observer.h
+++ b/DIRTY/include/scattered_weight_towards_observer.h
@@ -14,6 +14,7 @@
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 #endif

--- a/DIRTY/include/setup_dust_grid_dexp_disk.h
+++ b/DIRTY/include/setup_dust_grid_dexp_disk.h
@@ -23,9 +23,10 @@ extern void determine_photon_position_index_initial (geometry_struct& geometry,
 						     photon_data& photon);
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      int& escape,
-				      double& tau_traveled);
+// extern double calc_photon_trajectory (photon_data& photon,
+// 				      geometry_struct& geometry,
+// 				      double target_tau,
+// 				      double target_dist,
+// 				      int& escape,
+// 				      double& tau_traveled);
 #endif

--- a/DIRTY/include/stellar_weight_towards_observer.h
+++ b/DIRTY/include/stellar_weight_towards_observer.h
@@ -17,6 +17,7 @@ extern void determine_photon_position_index_initial (geometry_struct& geometry,
 extern double calc_photon_trajectory (photon_data& photon,
 				      geometry_struct& geometry,
 				      double target_tau,
+				      double target_dist,
 				      int& escape,
 				      double& tau_traveled);
 #endif

--- a/DIRTY/new_photon_diffuse_source.cpp
+++ b/DIRTY/new_photon_diffuse_source.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
-//   Procedure to generate a photon and set up the stats on it.          
-// This procedure is used for a single star located somewhere in the 
+//   Procedure to generate a photon and set up the stats on it.
+// This procedure is used for a single star located somewhere in the
 // dust distribution
 //
 // 2006 Nov/KDG - written
@@ -19,13 +19,13 @@ void new_photon_diffuse_source (photon_data& photon,
   // setup the weights
   photon.stellar_weight = 1.0;
   photon.scat_weight = 0.0;
-  
+
   // initialize statistics variables
   photon.num_scat = 0;
-  
+
   // save the photon info for later
   //   photon_data save_photon = photon;
-  
+
   double phi = 0.0;
   int i = 0;
   if (geometry.new_photon_source_type == NEW_PHOTON_DIFFUSE_ISOTROPIC) {
@@ -42,7 +42,7 @@ void new_photon_diffuse_source (photon_data& photon,
   } else {
     // determine which bin the photon emerges from
     double ran_num = random_obj.random_num();
-    while ((i < int(geometry.diffuse_source_sum_intensity.size())) && (ran_num > geometry.diffuse_source_sum_intensity[i])) i++; 
+    while ((i < int(geometry.diffuse_source_sum_intensity.size())) && (ran_num > geometry.diffuse_source_sum_intensity[i])) i++;
     int pos_index = i;
 //     cout << geometry.diffuse_source_theta[pos_index] << " ";
 //     cout << geometry.diffuse_source_phi[pos_index] << endl;
@@ -50,16 +50,16 @@ void new_photon_diffuse_source (photon_data& photon,
     cout << "theta = " << geometry.diffuse_source_theta[pos_index] << endl;
     cout << "phi = " << geometry.diffuse_source_phi[pos_index] << endl;
 #endif
-    
-    // direction of photon 
+
+    // direction of photon
     // from diffuse source location
     phi = geometry.diffuse_source_phi[pos_index];
     photon.dir_cosines[2] = cos(geometry.diffuse_source_theta[pos_index]+(M_PI/2.));
     double temp = sqrt(1.0 - pow(photon.dir_cosines[2],2));
     photon.dir_cosines[0] = cos(phi)*temp;
-    photon.dir_cosines[1] = sin(phi)*temp; 
+    photon.dir_cosines[1] = sin(phi)*temp;
   }
-  
+
 #ifdef DEBUG_NPDS
   cout << "photon.dir_cosines[0..2] = ";
   cout << photon.dir_cosines[0] << " ";
@@ -117,6 +117,7 @@ void new_photon_diffuse_source (photon_data& photon,
 
   // now move the photon to the edge
   double target_tau = 1e20;
+  double target_dist = 1e10*geometry.radius;
   int escape = 0;
   double distance_traveled = 0.0;
   double tau_to_surface = 0.0;
@@ -125,7 +126,7 @@ void new_photon_diffuse_source (photon_data& photon,
   cout << "np; start distance traveled" << " ";
   cout.flush();
 #endif
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, escape, tau_to_surface);
+  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_to_surface);
 #ifdef DEBUG_NPDS
   cout << "np; done distance traveled" << " ";
   cout.flush();

--- a/DIRTY/next_scatter.cpp
+++ b/DIRTY/next_scatter.cpp
@@ -1,6 +1,6 @@
 // ======================================================================
 //   Procedure to scatter a photon into a new direction.  This procedure
-// returns a 0 if the photon scatters inside the dust and a 1 if it 
+// returns a 0 if the photon scatters inside the dust and a 1 if it
 // escapes.
 //
 // 2004 Dec/KDG - written
@@ -19,11 +19,12 @@ int next_scatter (geometry_struct& geometry,
   photon_data dummy_photon = photon;
   dummy_photon.current_grid_num = 0;  // set to the base grid to start tarjectory correctly
   dummy_photon.path_cur_cells = 0; // set to 0 to save cells traversed
-  
+
   double target_tau = 1e20;
+  double target_dist = 1e10*geometry.radius;
   int escape = 0;
   double tau_path = 0.0;
-  calc_photon_trajectory(dummy_photon, geometry, target_tau, escape, tau_path);
+  calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, escape, tau_path);
   double bias_norm = 1.0/(1.0 + tau_path);
 //   cout << tau_path << " ";
 //   cout << bias_norm << " ";
@@ -50,14 +51,14 @@ int next_scatter (geometry_struct& geometry,
 #endif
     photon.current_grid_num = 0;
   }
-  
+
   // determine the site of the next scattering
   double distance_traveled = 0.0;
   double tau_traveled = 0.0;
   escape = 0;
   photon.path_cur_cells = 0;  // set to 0 to save cells tranversed
 
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, escape, tau_traveled);
+  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled);
 #ifdef DEBUG_NS
   if (photon.number == OUTNUM) {
     cout << "ns cpt done; ";
@@ -68,7 +69,7 @@ int next_scatter (geometry_struct& geometry,
 #endif
 
 //   int j = 0;
-//   for (j = 0; j < 3; j++) 
+//   for (j = 0; j < 3; j++)
 //     cout << photon.position[j] << " ";
 //   cout << endl;
 

--- a/DIRTY/output_model_grid.cpp
+++ b/DIRTY/output_model_grid.cpp
@@ -222,7 +222,7 @@ void output_model_grid (geometry_struct& geometry,
 
       // extra information needed for setting up the geometry
       fits_write_key(out_tau_ptr, TFLOAT, "RAD_TAU", &geometry.tau, "radial optical depth", &status);
-      fits_write_key(out_tau_ptr, TLONG, "GRDDEPTH", &geometry.max_grid_depth, "maximum depth of the grid", &status);
+      fits_write_key(out_tau_ptr, TINT, "GRDDEPTH", &geometry.max_grid_depth, "maximum depth of the grid", &status);
 
       // final stuff for primary header
       fits_write_comment(out_tau_ptr, "**---------------------------------**",&status);

--- a/DIRTY/output_model_grid.cpp
+++ b/DIRTY/output_model_grid.cpp
@@ -200,7 +200,7 @@ void output_model_grid (geometry_struct& geometry,
 //     check_fits_io(status,"fits_write_key : output_model_grid (pos)");
 
     if (m != 0) {
-      fits_write_key(out_tau_ptr, TINT, "PAR_GRID", &geometry.grids[m].parent_grid_num, "grid number of partent", &status);
+      fits_write_key(out_tau_ptr, TINT, "PAR_GRID", &geometry.grids[m].parent_grid_num, "grid number of parent", &status);
     } else {
       // populate the primary header with the details of the run
 

--- a/DIRTY/scatter_photon.cpp
+++ b/DIRTY/scatter_photon.cpp
@@ -1,5 +1,5 @@
 // ======================================================================
-//   Procedure to scatter a photon into a new direction.  
+//   Procedure to scatter a photon into a new direction.
 //
 // 2004 Dec/KDG - written
 // 2008 Aug/KDG - added continous absorption
@@ -34,7 +34,7 @@ void scatter_photon (geometry_struct& geometry,
 //       cout << i1 << " " << i3 << endl;
       i2 = (i1 + i3)/2;
     }
-    cos_alpha = geometry.phi_angle[i1] - 
+    cos_alpha = geometry.phi_angle[i1] -
       ((rannum - geometry.phi_sum[i3])/(geometry.phi_sum[i1] - geometry.phi_sum[i3]))*
       (geometry.phi_angle[i1] - geometry.phi_angle[i3]);
 //     cout << float(i1)/float(geometry.phi.size()) << " ";
@@ -51,13 +51,13 @@ void scatter_photon (geometry_struct& geometry,
     double ran_num = random_obj.random_num();
     double ran_num2 = random_obj.random_num();
     if (ran_num >= geometry.scat_angle_bias_fraction) { // sample from HG function
-      cos_alpha = (1.0 + sqr_g) - 
+      cos_alpha = (1.0 + sqr_g) -
 	pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*ran_num2),2);
       cos_alpha /= (2.0*geometry.g);
     } else { // sample from isotropic function
       cos_alpha = 2.0*ran_num2 - 1.0;
     }
-    
+
     // multiplicative weight needed
     double biased_weight_factor = 0.0;
     biased_weight_factor = (1.0 - geometry.scat_angle_bias_fraction) +
@@ -77,7 +77,7 @@ void scatter_photon (geometry_struct& geometry,
   } else if (geometry.g > ROUNDOFF_ERR_TRIG) {
     sqr_g = pow(geometry.g,2);
 
-    cos_alpha = (1.0 + sqr_g) - 
+    cos_alpha = (1.0 + sqr_g) -
       pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*random_obj.random_num()),2);
     cos_alpha /= (2.0*geometry.g);
 
@@ -116,13 +116,13 @@ void scatter_photon (geometry_struct& geometry,
 
   // update the direction cosines of the photon
   int i;
-  for (i = 0; i < 3; i++) 
+  for (i = 0; i < 3; i++)
     photon.dir_cosines[i] = new_dir_cosines[i];
 
 #ifdef DEBUG_SP
   cout << "# scat = " << photon.num_scat << endl;
   cout << "total tau = " << photon.target_tau << endl;
-#endif  
+#endif
 
   // update the scattered weight
   photon.scat_weight *= geometry.albedo;
@@ -144,9 +144,10 @@ void scatter_photon (geometry_struct& geometry,
     dummy_photon.path_cur_cells = 0; // set to 0 to save cells traversed
 
     double target_tau = 1e20;
+    double target_dist = 1e10*geometry.radius;
     int escape = 0;
     double tau_to_surface = 0.0;
-    calc_photon_trajectory(dummy_photon, geometry, target_tau, escape, tau_to_surface);
+    calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, escape, tau_to_surface);
 
     photon.prev_tau_surface = tau_to_surface;
 
@@ -161,7 +162,7 @@ void scatter_photon (geometry_struct& geometry,
 
     double tau_entering = 0.;
     double prob_entering = 1.;
-    
+
 #ifdef DEBUG_SP
     double tot_abs_temp = 0.;
 #endif
@@ -183,9 +184,9 @@ void scatter_photon (geometry_struct& geometry,
       cout << prob_entering << " ";
       cout << prob_leaving << " ";
       cout << abs_weight << endl;
-      
+
       tot_abs_temp += abs_weight;
-#endif  
+#endif
 
       // deposit the energy
       grid_cell& this_cell = geometry.grids[dummy_photon.path_pos_index[0][i]].grid(dummy_photon.path_pos_index[1][i],dummy_photon.path_pos_index[2][i],dummy_photon.path_pos_index[3][i]);

--- a/DIRTY/scattered_weight_towards_observer.cpp
+++ b/DIRTY/scattered_weight_towards_observer.cpp
@@ -5,12 +5,12 @@
 // 2006 Apr/KDG - written
 // ======================================================================
 #include "scattered_weight_towards_observer.h"
-//#define OUTNUM 73145
-//#define DEBUG_SWTO
+// #define OUTNUM 73145
+// #define DEBUG_SWTO
 
-double scattered_weight_towards_observer (photon_data photon,
-					  geometry_struct& geometry,
-					  float observer_position[3])
+double scattered_weight_towards_observer(photon_data photon,
+                                         geometry_struct& geometry,
+                                         float observer_position[3])
 
 {
   // determine the vector, distance, and direction cosines from the scattering
@@ -21,33 +21,29 @@ double scattered_weight_towards_observer (photon_data photon,
   int i;
   for (i = 0; i < 3; i++) {
     scat_to_obs[i] = observer_position[i] - photon.position[i];
-    dist_scat_to_obs += pow(scat_to_obs[i],2);
+    dist_scat_to_obs += pow(scat_to_obs[i], 2);
   }
   dist_scat_to_obs = sqrt(dist_scat_to_obs);
   for (i = 0; i < 3; i++)
-    dir_cosines_scat_to_obs[i] = scat_to_obs[i]/dist_scat_to_obs;
+    dir_cosines_scat_to_obs[i] = scat_to_obs[i] / dist_scat_to_obs;
 
 #ifdef DEBUG_SWTO
   if (photon.number == OUTNUM) {
     cout << "pos vector = ";
-    for (i = 0; i < 3; i++)
-      cout << photon.position[i] << " ";
+    for (i = 0; i < 3; i++) cout << photon.position[i] << " ";
     cout << endl;
     cout << "dir cosines vector = ";
-    for (i = 0; i < 3; i++)
-      cout << photon.dir_cosines[i] << " ";
+    for (i = 0; i < 3; i++) cout << photon.dir_cosines[i] << " ";
     cout << endl;
     cout << "scat_to_obs vector = ";
-    for (i = 0; i < 3; i++)
-      cout << scat_to_obs[i] << " ";
+    for (i = 0; i < 3; i++) cout << scat_to_obs[i] << " ";
     cout << endl;
-     cout << "scat_to_obs dir_cosines = ";
-    for (i = 0; i < 3; i++)
-      cout << dir_cosines_scat_to_obs[i] << " ";
+    cout << "scat_to_obs dir_cosines = ";
+    for (i = 0; i < 3; i++) cout << dir_cosines_scat_to_obs[i] << " ";
     cout << endl;
     cout << "cos_alpha contributions = ";
     for (i = 0; i < 3; i++)
-      cout << dir_cosines_scat_to_obs[i]*photon.dir_cosines[i] << " ";
+      cout << dir_cosines_scat_to_obs[i] * photon.dir_cosines[i] << " ";
     cout << endl;
   }
 #endif
@@ -56,7 +52,7 @@ double scattered_weight_towards_observer (photon_data photon,
   // the direction to the observer
   double cos_alpha = 0.0;
   for (i = 0; i < 3; i++)
-    cos_alpha += dir_cosines_scat_to_obs[i]*photon.dir_cosines[i];
+    cos_alpha += dir_cosines_scat_to_obs[i] * photon.dir_cosines[i];
   // check the resulting value is reasonable
   if (fabs(cos_alpha) > 1.0) {
     cout << "ERROR: scattered_weight_towards_observer" << endl;
@@ -64,35 +60,38 @@ double scattered_weight_towards_observer (photon_data photon,
     exit(8);
   }
 
-//   double scat_weight = 0.0;
-  //scat_weight += dir_cosines_scat_to_obs[0]*photon.dir_cosines[0];
-  //scat_weight += dir_cosines_scat_to_obs[1]*photon.dir_cosines[1];
-//   scat_weight += dir_cosines_scat_to_obs[2]*photon.dir_cosines[2];
+  //   double scat_weight = 0.0;
+  // scat_weight += dir_cosines_scat_to_obs[0]*photon.dir_cosines[0];
+  // scat_weight += dir_cosines_scat_to_obs[1]*photon.dir_cosines[1];
+  //   scat_weight += dir_cosines_scat_to_obs[2]*photon.dir_cosines[2];
 
   // determine the optical depth to the surface from the scattering site
   // towards the observer
-  for (i = 0; i < 3; i++)
-    photon.dir_cosines[i] = dir_cosines_scat_to_obs[i];
+  for (i = 0; i < 3; i++) photon.dir_cosines[i] = dir_cosines_scat_to_obs[i];
   double target_tau = 1e20;
-  double target_dist = 1e10*geometry.radius;
+  double target_dist = 1e10 * geometry.radius;
+  if (geometry.internal_observer == 1) target_dist = dist_scat_to_obs;
   int escape = 0;
   double tau_scat_to_obs = 0.0;
   double distance_traveled = 0.0;
-  photon.current_grid_num = 0;  // set to the base grid to start tarjectory correctly
+  photon.current_grid_num =
+      0;  // set to the base grid to start tarjectory correctly
 #ifdef DEBUG_SWTO
   if (photon.number == OUTNUM) {
     cout << "starting calc_photon_traj..." << endl;
   }
 #endif
   try {
-    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_scat_to_obs);
-  } catch(std::out_of_range)
-    {
-      cout << "photon # = " << photon.number << endl;
-      cout << "num scat = " << photon.num_scat << endl;
-      cout << "scattered_weight_towards_observer: calc_photon_trajectory - out of range." << endl;
-      exit(8);
-    }
+    distance_traveled = calc_photon_trajectory(
+        photon, geometry, target_tau, target_dist, escape, tau_scat_to_obs);
+  } catch (std::out_of_range) {
+    cout << "photon # = " << photon.number << endl;
+    cout << "num scat = " << photon.num_scat << endl;
+    cout << "scattered_weight_towards_observer: calc_photon_trajectory - out "
+            "of range."
+         << endl;
+    exit(8);
+  }
 #ifdef DEBUG_SWTO
   if (photon.number == OUTNUM) {
     cout << "Tau from scattering site to surface = " << tau_scat_to_obs << endl;
@@ -104,36 +103,39 @@ double scattered_weight_towards_observer (photon_data photon,
 
   double scat_weight_angle = 0.0;
   // calculate the portion of the probability from the angle
-  if (geometry.g == -2) { // model phase function
-    uint i1,i2,i3;
+  if (geometry.g == -2) {  // model phase function
+    uint i1, i2, i3;
     i1 = 0;
     i3 = geometry.phi.size();
-    i2 = (i1 + i3)/2;
-//     cout << i3 << endl;
+    i2 = (i1 + i3) / 2;
+    //     cout << i3 << endl;
     while ((i3 - i1) > 1) {
-      if (cos_alpha < geometry.phi_angle[i2]) i1 = i2; else i3 = i2;
-//       cout << cos_alpha << " ";
-//       cout << geometry.phi_angle[i1] << " " << geometry.phi_angle[i3] << " ";
-//       cout << i1 << " " << i3 << endl;
-      i2 = (i1 + i3)/2;
+      if (cos_alpha < geometry.phi_angle[i2])
+        i1 = i2;
+      else
+        i3 = i2;
+      //       cout << cos_alpha << " ";
+      //       cout << geometry.phi_angle[i1] << " " << geometry.phi_angle[i3]
+      //       << " "; cout << i1 << " " << i3 << endl;
+      i2 = (i1 + i3) / 2;
     }
-    scat_weight_angle = geometry.phi[i1] +
-      ((cos_alpha - geometry.phi_angle[i3])/(geometry.phi_angle[i1] - geometry.phi_angle[i3]))*
-      (geometry.phi[i1] - geometry.phi[i3]);
-//     cout << ((cos_alpha - geometry.phi_angle[i3])/(geometry.phi_angle[i1] - geometry.phi_angle[i3])) <<  endl;
-//     cout << cos_alpha << endl;
-//     cout << geometry.phi_angle[i1] << endl;
-//     cout << geometry.phi[i1] << " " << geometry.phi[i3] << endl;
-//     cout << scat_weight_angle << endl;
-//     double tmp_g = 0.384;
-//     cout << ((1.0 - pow(tmp_g,2))/
-// 	     (4.0*M_PI*pow(1.0 + pow(tmp_g,2) -
-// 			   2.0*tmp_g*cos_alpha,1.5))) << endl;
-//     exit(8);
+    scat_weight_angle =
+        geometry.phi[i1] + ((cos_alpha - geometry.phi_angle[i3]) /
+                            (geometry.phi_angle[i1] - geometry.phi_angle[i3])) *
+                               (geometry.phi[i1] - geometry.phi[i3]);
+    //     cout << ((cos_alpha - geometry.phi_angle[i3])/(geometry.phi_angle[i1]
+    //     - geometry.phi_angle[i3])) <<  endl; cout << cos_alpha << endl; cout
+    //     << geometry.phi_angle[i1] << endl; cout << geometry.phi[i1] << " " <<
+    //     geometry.phi[i3] << endl; cout << scat_weight_angle << endl; double
+    //     tmp_g = 0.384; cout << ((1.0 - pow(tmp_g,2))/
+    // 	     (4.0*M_PI*pow(1.0 + pow(tmp_g,2) -
+    // 			   2.0*tmp_g*cos_alpha,1.5))) << endl;
+    //     exit(8);
   } else {
-    scat_weight_angle = ((1.0 - pow(geometry.g,2))/
-			 (4.0*M_PI*pow(1.0 + pow(geometry.g,2) -
-				       2.0*geometry.g*cos_alpha,1.5)));
+    scat_weight_angle =
+        ((1.0 - pow(geometry.g, 2)) /
+         (4.0 * M_PI *
+          pow(1.0 + pow(geometry.g, 2) - 2.0 * geometry.g * cos_alpha, 1.5)));
   }
   scat_weight_angle *= geometry.solid_angle;
 
@@ -149,12 +151,12 @@ double scattered_weight_towards_observer (photon_data photon,
 #endif
 
   // udpate scattered weight
-  scat_weight *= scat_weight_angle*scat_weight_tau;
-//   scat_weight = cos_alpha;
+  scat_weight *= scat_weight_angle * scat_weight_tau;
+  //   scat_weight = cos_alpha;
 
-//   if (scat_weight > 1.) {
-//     exit(8);
-//   }
+  //   if (scat_weight > 1.) {
+  //     exit(8);
+  //   }
 
-  return(scat_weight);
+  return (scat_weight);
 }

--- a/DIRTY/scattered_weight_towards_observer.cpp
+++ b/DIRTY/scattered_weight_towards_observer.cpp
@@ -1,5 +1,5 @@
 // ======================================================================
-//   Function to calculate the scattered weight in the direction of the 
+//   Function to calculate the scattered weight in the direction of the
 // observer.
 //
 // 2006 Apr/KDG - written
@@ -11,7 +11,7 @@
 double scattered_weight_towards_observer (photon_data photon,
 					  geometry_struct& geometry,
 					  float observer_position[3])
-  
+
 {
   // determine the vector, distance, and direction cosines from the scattering
   // site to the observer
@@ -30,23 +30,23 @@ double scattered_weight_towards_observer (photon_data photon,
 #ifdef DEBUG_SWTO
   if (photon.number == OUTNUM) {
     cout << "pos vector = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << photon.position[i] << " ";
     cout << endl;
     cout << "dir cosines vector = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << photon.dir_cosines[i] << " ";
     cout << endl;
     cout << "scat_to_obs vector = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << scat_to_obs[i] << " ";
     cout << endl;
      cout << "scat_to_obs dir_cosines = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << dir_cosines_scat_to_obs[i] << " ";
     cout << endl;
     cout << "cos_alpha contributions = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << dir_cosines_scat_to_obs[i]*photon.dir_cosines[i] << " ";
     cout << endl;
   }
@@ -74,6 +74,7 @@ double scattered_weight_towards_observer (photon_data photon,
   for (i = 0; i < 3; i++)
     photon.dir_cosines[i] = dir_cosines_scat_to_obs[i];
   double target_tau = 1e20;
+  double target_dist = 1e10*geometry.radius;
   int escape = 0;
   double tau_scat_to_obs = 0.0;
   double distance_traveled = 0.0;
@@ -84,7 +85,7 @@ double scattered_weight_towards_observer (photon_data photon,
   }
 #endif
   try {
-    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, escape, tau_scat_to_obs);
+    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_scat_to_obs);
   } catch(std::out_of_range)
     {
       cout << "photon # = " << photon.number << endl;
@@ -116,9 +117,9 @@ double scattered_weight_towards_observer (photon_data photon,
 //       cout << i1 << " " << i3 << endl;
       i2 = (i1 + i3)/2;
     }
-    scat_weight_angle = geometry.phi[i1] + 
+    scat_weight_angle = geometry.phi[i1] +
       ((cos_alpha - geometry.phi_angle[i3])/(geometry.phi_angle[i1] - geometry.phi_angle[i3]))*
-      (geometry.phi[i1] - geometry.phi[i3]); 
+      (geometry.phi[i1] - geometry.phi[i3]);
 //     cout << ((cos_alpha - geometry.phi_angle[i3])/(geometry.phi_angle[i1] - geometry.phi_angle[i3])) <<  endl;
 //     cout << cos_alpha << endl;
 //     cout << geometry.phi_angle[i1] << endl;
@@ -126,12 +127,12 @@ double scattered_weight_towards_observer (photon_data photon,
 //     cout << scat_weight_angle << endl;
 //     double tmp_g = 0.384;
 //     cout << ((1.0 - pow(tmp_g,2))/
-// 	     (4.0*M_PI*pow(1.0 + pow(tmp_g,2) - 
+// 	     (4.0*M_PI*pow(1.0 + pow(tmp_g,2) -
 // 			   2.0*tmp_g*cos_alpha,1.5))) << endl;
 //     exit(8);
   } else {
     scat_weight_angle = ((1.0 - pow(geometry.g,2))/
-			 (4.0*M_PI*pow(1.0 + pow(geometry.g,2) - 
+			 (4.0*M_PI*pow(1.0 + pow(geometry.g,2) -
 				       2.0*geometry.g*cos_alpha,1.5)));
   }
   scat_weight_angle *= geometry.solid_angle;

--- a/DIRTY/setup_dust_grid.cpp
+++ b/DIRTY/setup_dust_grid.cpp
@@ -21,58 +21,6 @@ void setup_dust_grid (ConfigFile& param_data,
   geometry.distance = param_data.FValue("Geometry","distance");
   check_input_param("distance",geometry.distance,0.0,1e38);
 
-  // number of observers 
-  //  (currently only 1 allowed, need to expand to reading in a file with more observer positions)
-  geometry.num_observers = param_data.IValue("Geometry","n_obs_angles");
-  check_input_param("n_obs_angles",geometry.num_observers,1,100);
-
-  if (geometry.num_observers == 1) {
-    // read in observer angles and convert to radians
-    geometry.observer_angles[0][0] = param_data.FValue("Geometry","obs_theta");
-    check_input_param("obs_theta",geometry.observer_angles[0][0],0.,180.);
-    geometry.observer_angles[0][0] *= M_PI/180.;
-
-    geometry.observer_angles[1][0] = param_data.FValue("Geometry","obs_phi");
-    check_input_param("obs_theta",geometry.observer_angles[1][0],0.,360.);
-    geometry.observer_angles[1][0] *= M_PI/180.;
-  } else {
-    // get the filename
-    string multiple_obs_filename = param_data.SValue("Geometry","obs_file");
-    // check that the file exists
-    ifstream multiple_obs_file(multiple_obs_filename.c_str());
-    if (multiple_obs_file.fail()) {
-      cout << "Multiple obs file w/ positions (" << multiple_obs_filename << ") does not exist." << endl;
-      exit(8);
-    }
-    multiple_obs_file.close();
-      
-    // read in the positions
-    vector<double> obs_theta,obs_phi;
-    DataFile(multiple_obs_filename, obs_theta, obs_phi);
-      
-    // check we got the number of positions we expected
-    if (int(obs_theta.size()) != geometry.num_observers) {
-      cout << "The number of directions in multiple observers file (" << obs_theta.size() << ")" << endl;
-      cout << "does not match the number expected (" << geometry.num_observers << ")" << endl;
-      exit(8);
-    }
-      
-    // test the results and put them into the appropriate locations
-    int i;
-    for (i = 0; i < geometry.num_observers; i++) {
-      check_input_param("multiple obs obs_theta",obs_theta[i],0.0,180.0);
-      check_input_param("multiple obs obs_theta",obs_phi[i],0.0,360.0);
-	
-      geometry.observer_angles[0][i] = obs_theta[i]*M_PI/180.;
-      geometry.observer_angles[1][i] = obs_phi[i]*M_PI/180.;
-    }
-  }
-
-  // randomize observer position
-  geometry.randomize_observer = param_data.IValue("Geometry","randomize_observer");
-  if (geometry.randomize_observer == -99) geometry.randomize_observer = 0;
-  check_input_param("ranomize_observer",geometry.randomize_observer,0,1);
-
   // setup the dust grid proper depending on type
   geometry.type = param_data.SValue("Geometry","type");
     //  if (strcmp(geometry.type.c_str(),"sphere")) {
@@ -98,14 +46,14 @@ void setup_dust_grid (ConfigFile& param_data,
 
   // get the source type
   geometry.source_type = param_data.SValue("Geometry","source_type");
-  
+
   if (geometry.source_type == "stars") {
     // set the solid angle (stars emit isotropically)
     geometry.solid_angle = 4.*M_PI;
 
     geometry.new_photon_source_type = NEW_PHOTON_DISCRETE_STARS;
-    
-    // number of stars 
+
+    // number of stars
     geometry.num_stars = param_data.IValue("Geometry","n_stars");
     check_input_param("n_stars",geometry.num_stars,1,MAX_MULTIPLE_STARS);
 
@@ -129,18 +77,18 @@ void setup_dust_grid (ConfigFile& param_data,
 	exit(8);
       }
       multiple_stars_file.close();
-      
+
       // read in the positions
       vector<double> pos_x,pos_y,pos_z,lum;
       DataFile(multiple_stars_filename, pos_x, pos_y, pos_z, lum);
-      
+
       // check we got the number of positions we expected
       if (int(pos_x.size()) != geometry.num_stars) {
 	cout << "The number of positions in multiple star file (" << pos_x.size() << ")" << endl;
 	cout << "does not match the number expected (" << geometry.num_stars << ")" << endl;
 	exit(8);
       }
-      
+
       // test the results and put them into the appropriate locations
       int i;
       for (i = 0; i < geometry.num_stars; i++) {
@@ -148,7 +96,7 @@ void setup_dust_grid (ConfigFile& param_data,
 	check_input_param("multiple star pos_y",pos_y[i],-1*geometry.grids[0].phys_grid_size[1]/2., geometry.grids[0].phys_grid_size[1]/2.);
 	check_input_param("multiple star pos_z",pos_z[i],-1*geometry.grids[0].phys_grid_size[2]/2., geometry.grids[0].phys_grid_size[2]/2.);
 	check_input_param("multiple star luminosity",lum[i],0.0,1e40);
-	
+
 	geometry.star_positions[0][i] = pos_x[i];
 	geometry.star_positions[1][i] = pos_y[i];
 	geometry.star_positions[2][i] = pos_z[i];
@@ -165,7 +113,7 @@ void setup_dust_grid (ConfigFile& param_data,
     }
   } else if (geometry.source_type == "diffuse") {
 
-    // set the solid angle 
+    // set the solid angle
     // assuming the diffuse field convers 4*pi sr
     // if not, then this should be set to the angular area of the emitted diffuse field
     // this would be the case for a diffuse field illuminating the source from just one direction
@@ -189,11 +137,11 @@ void setup_dust_grid (ConfigFile& param_data,
 	exit(8);
       }
       source_file.close();
-      
+
       // read in the radiation field
       vector<double> theta, phi, intensity, sr_area;
       DataFile(source_filename, theta, phi, intensity, sr_area);
-      
+
       // test the results and put them into the appropriate locations
       int i;
       //double sum_lum = 0.0;  // running sum of the luminosity
@@ -202,7 +150,7 @@ void setup_dust_grid (ConfigFile& param_data,
 	check_input_param("diffuse source phi",phi[i],0.0,2.*M_PI);
 	check_input_param("diffuse source intensity",intensity[i],0,1e40);
 	check_input_param("diffuse source sr area",sr_area[i],0.,4.*M_PI);
-	
+
 	geometry.diffuse_source_theta.push_back(theta[i]);
 	geometry.diffuse_source_phi.push_back(phi[i]);
 	geometry.diffuse_source_intensity.push_back(intensity[i]);
@@ -214,7 +162,7 @@ void setup_dust_grid (ConfigFile& param_data,
       for (i = 0; i < int(theta.size()); i++) {
 	geometry.diffuse_source_sum_intensity[i] /= geometry.total_source_luminosity;
       }
-      
+
       // input source intensity in ergs s^-1 A^-1 cm^-2 sr^-1
       // need to get ride of cm^-2 and sr^-1 for total luminosity
 
@@ -234,32 +182,32 @@ void setup_dust_grid (ConfigFile& param_data,
       cout << "switch to sphere or write some more code" << endl;
       exit(8);
     }
-    
+
   } else if (geometry.source_type == "dexp_disk") {
     geometry.solid_angle = 4.*M_PI;
     geometry.new_photon_source_type = NEW_PHOTON_DEXP_DISK;
-	
+
   } else if (geometry.source_type == "pow_sphere") {
-  
+
     geometry.solid_angle = 4.*M_PI;
     geometry.new_photon_source_type = NEW_PHOTON_POW_SPHERE;
-    
+
     double alpha = param_data.FValue("Geometry","pow_sphere_exponent");
     // if (isnan(alpha)) alpha = 0.;
     check_input_param("pow_sphere_exponent", alpha, -100., 100.);
     geometry.pow_sphere_exponent = alpha;
-    
+
     double rmax = param_data.FValue("Geometry","radius");
     double r1 = param_data.FValue("Geometry","pow_sphere_inner_radius");
     // if (isnan(r1)) r1 = 0.;
     check_input_param("pow_sphere_inner_radius", r1, 0., rmax);
     geometry.pow_sphere_inner_radius = r1;
-    
+
     double r2 = param_data.FValue("Geometry","pow_sphere_outer_radius");
     // if (isnan(r2)) r2 = rmax;
     check_input_param("pow_sphere_outer_radius", r2, r1, rmax);
     geometry.pow_sphere_outer_radius = r2;
-    
+
     if (alpha == -3.) {
       cout << "pow_sphere: exponent == -3 case not implemented (need logarithm)" << endl;
       exit(8);
@@ -271,11 +219,88 @@ void setup_dust_grid (ConfigFile& param_data,
     geometry.pow_sphere_constant1 = pow(r2, 3.0+alpha) - pow(r1, 3.0+alpha);
     geometry.pow_sphere_constant2 = pow(r1, 3.0+alpha);
     geometry.pow_sphere_constant3 = 1.0/(3.0+alpha);
-    
+
   } else {
     cout << "Setup for input source type (" << geometry.source_type << ") not found [NEW CODE NEEDED]." << endl;
     exit(8);
   }
+
+  // set the observer details
+
+  // number of observers (internal or external)
+  //  poorly named input parameter name (now that internal observers are possible)
+  geometry.num_observers = param_data.IValue("Geometry","n_obs_angles");
+  check_input_param("n_obs_angles",geometry.num_observers,1,100);
+
+  // check if an internal observer position is set
+  geometry.internal_observer = param_data.IValue("Geometry","internal_obs");
+  if (geometry.internal_observer == -99) geometry.internal_observer = 0;
+  check_input_param("internal_obs",geometry.internal_observer,0,1);
+
+  if (geometry.num_observers == 1) {
+
+    // external observer: read in observer angles and convert to radians
+    if (geometry.internal_observer == 0) {
+      geometry.observer_angles[0][0] = param_data.FValue("Geometry","obs_theta");
+      check_input_param("obs_theta",geometry.observer_angles[0][0],0.,180.);
+      geometry.observer_angles[0][0] *= M_PI/180.;
+
+      geometry.observer_angles[1][0] = param_data.FValue("Geometry","obs_phi");
+      check_input_param("obs_theta",geometry.observer_angles[1][0],0.,360.);
+      geometry.observer_angles[1][0] *= M_PI/180.;
+    } else { // internal observer
+      geometry.observer_position[0] = param_data.FValue("Geometry","obs_x");
+      check_input_param("obs_x",geometry.observer_position[0],-1.0*geometry.radius,geometry.radius);
+      geometry.observer_position[1] = param_data.FValue("Geometry","obs_y");
+      check_input_param("obs_y",geometry.observer_position[0],-1.0*geometry.radius,geometry.radius);
+      geometry.observer_position[2] = param_data.FValue("Geometry","obs_z");
+      check_input_param("obs_z",geometry.observer_position[0],-1.0*geometry.radius,geometry.radius);
+    }
+
+  } else {
+
+    // multiple internal observers not implemented (yet)
+    if (geometry.internal_observer == 1) {
+       cout << "multiple internal observers not implemented (yet)" << endl;
+       exit(8);
+    }
+
+    // get the filename
+    string multiple_obs_filename = param_data.SValue("Geometry","obs_file");
+    // check that the file exists
+    ifstream multiple_obs_file(multiple_obs_filename.c_str());
+    if (multiple_obs_file.fail()) {
+      cout << "Multiple obs file w/ positions (" << multiple_obs_filename << ") does not exist." << endl;
+      exit(8);
+    }
+    multiple_obs_file.close();
+
+    // read in the positions
+    vector<double> obs_theta,obs_phi;
+    DataFile(multiple_obs_filename, obs_theta, obs_phi);
+
+    // check we got the number of positions we expected
+    if (int(obs_theta.size()) != geometry.num_observers) {
+      cout << "The number of directions in multiple observers file (" << obs_theta.size() << ")" << endl;
+      cout << "does not match the number expected (" << geometry.num_observers << ")" << endl;
+      exit(8);
+    }
+
+    // test the results and put them into the appropriate locations
+    int i;
+    for (i = 0; i < geometry.num_observers; i++) {
+      check_input_param("multiple obs obs_theta",obs_theta[i],0.0,180.0);
+      check_input_param("multiple obs obs_theta",obs_phi[i],0.0,360.0);
+
+      geometry.observer_angles[0][i] = obs_theta[i]*M_PI/180.;
+      geometry.observer_angles[1][i] = obs_phi[i]*M_PI/180.;
+    }
+  }
+
+  // randomize observer position
+  geometry.randomize_observer = param_data.IValue("Geometry","randomize_observer");
+  if (geometry.randomize_observer == -99) geometry.randomize_observer = 0;
+  check_input_param("ranomize_observer",geometry.randomize_observer,0,1);
 
   // setup the photon structure with positions for the maximum grid depth
   vector<int> one_index(3);

--- a/DIRTY/setup_dust_grid_file.cpp
+++ b/DIRTY/setup_dust_grid_file.cpp
@@ -190,6 +190,12 @@ void setup_dust_grid_file (ConfigFile& param_data,
       }
       check_input_param("arbitrary file: radial optical depth",geometry.tau,0.0,1000.);
 
+      // variables that are not used, but are written to an output FITS file
+      // need to be set to avoid bad float to string conversions in creating the FITS file
+      geometry.density_ratio = 1.0;
+      geometry.clump_densities[0] = 0.0;
+      geometry.clump_densities[1] = 0.0;
+
       // max grid depth
       fits_read_key(tau_pc_file_ptr, TLONG, "GRDDEPTH", &geometry.max_grid_depth, comment, &status);
       if (status != 0) {

--- a/DIRTY/stellar_weight_towards_observer.cpp
+++ b/DIRTY/stellar_weight_towards_observer.cpp
@@ -1,5 +1,5 @@
 // ======================================================================
-//   Function to calculate the stellar weight in the direction of the 
+//   Function to calculate the stellar weight in the direction of the
 // observer.
 //
 // 2007 Feb/KDG - written (adapted from scattered_weight_towards_observer)
@@ -11,7 +11,7 @@
 double stellar_weight_towards_observer (photon_data photon,
 					geometry_struct& geometry,
 					float observer_position[3])
-  
+
 {
   // determine the vector, distance, and direction cosines from the photon
   // birth site to the observer
@@ -30,11 +30,11 @@ double stellar_weight_towards_observer (photon_data photon,
 #ifdef DEBUG_STWTO
   if (photon.number == OUTNUM) {
     cout << "birth_to_obs vector = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << birth_to_obs[i] << " ";
     cout << endl;
     cout << "birth_to_obs dir_cosines = ";
-    for (i = 0; i < 3; i++) 
+    for (i = 0; i < 3; i++)
       cout << dir_cosines_birth_to_obs[i] << " ";
     cout << endl;
   }
@@ -45,6 +45,7 @@ double stellar_weight_towards_observer (photon_data photon,
   for (i = 0; i < 3; i++)
     photon.dir_cosines[i] = dir_cosines_birth_to_obs[i];
   double target_tau = 1e20;
+  double target_dist = 1e10*geometry.radius;
   int escape = 0;
   double tau_birth_to_obs = 0.0;
 
@@ -52,7 +53,7 @@ double stellar_weight_towards_observer (photon_data photon,
   // immediate exit from the grid, step back slightly to avoid this
   for (i = 0; i < 3; i++) {
     if ((photon.dir_cosines[i] < 0.) && (photon.position[i] == geometry.grids[photon.current_grid_num].positions[i][0]))
-      photon.position[i] += 0.01*(geometry.grids[photon.current_grid_num].positions[i][1] - 
+      photon.position[i] += 0.01*(geometry.grids[photon.current_grid_num].positions[i][1] -
 				  geometry.grids[photon.current_grid_num].positions[i][0]);
     else if ((photon.dir_cosines[i] > 0.) && (photon.position[i] == geometry.grids[photon.current_grid_num].positions[i][geometry.grids[photon.current_grid_num].index_dim[i]]))
       photon.position[i] -= 0.01*(geometry.grids[photon.current_grid_num].positions[i][geometry.grids[photon.current_grid_num].index_dim[i]] -
@@ -82,7 +83,7 @@ double stellar_weight_towards_observer (photon_data photon,
 #endif
 
   double distance_traveled = 0.0;
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, escape, tau_birth_to_obs);
+  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_birth_to_obs);
 #ifdef DEBUG_STWTO
   if (photon.number == OUTNUM) {
     cout << "tau/distance traveled = " << tau_birth_to_obs << " ";

--- a/DIRTY/stellar_weight_towards_observer.cpp
+++ b/DIRTY/stellar_weight_towards_observer.cpp
@@ -43,7 +43,7 @@ double stellar_weight_towards_observer(photon_data photon,
   for (i = 0; i < 3; i++) photon.dir_cosines[i] = dir_cosines_birth_to_obs[i];
   double target_tau = 1e20;
   double target_dist = 1e10 * geometry.radius;
-  if (geometry.internal_observer == 1) target_tau = dist_birth_to_obs;
+  if (geometry.internal_observer == 1) target_dist = dist_birth_to_obs;
   int escape = 0;
   double tau_birth_to_obs = 0.0;
 

--- a/DIRTY/stellar_weight_towards_observer.cpp
+++ b/DIRTY/stellar_weight_towards_observer.cpp
@@ -5,12 +5,12 @@
 // 2007 Feb/KDG - written (adapted from scattered_weight_towards_observer)
 // ======================================================================
 #include "stellar_weight_towards_observer.h"
-//#define DEBUG_STWTO
-//#define OUTNUM 1
+// #define DEBUG_STWTO
+// #define OUTNUM 1
 
-double stellar_weight_towards_observer (photon_data photon,
-					geometry_struct& geometry,
-					float observer_position[3])
+double stellar_weight_towards_observer(photon_data photon,
+                                       geometry_struct& geometry,
+                                       float observer_position[3])
 
 {
   // determine the vector, distance, and direction cosines from the photon
@@ -21,43 +21,51 @@ double stellar_weight_towards_observer (photon_data photon,
   int i;
   for (i = 0; i < 3; i++) {
     birth_to_obs[i] = observer_position[i] - photon.position[i];
-    dist_birth_to_obs += pow(birth_to_obs[i],2);
+    dist_birth_to_obs += pow(birth_to_obs[i], 2);
   }
   dist_birth_to_obs = sqrt(dist_birth_to_obs);
   for (i = 0; i < 3; i++)
-    dir_cosines_birth_to_obs[i] = birth_to_obs[i]/dist_birth_to_obs;
+    dir_cosines_birth_to_obs[i] = birth_to_obs[i] / dist_birth_to_obs;
 
 #ifdef DEBUG_STWTO
   if (photon.number == OUTNUM) {
     cout << "birth_to_obs vector = ";
-    for (i = 0; i < 3; i++)
-      cout << birth_to_obs[i] << " ";
+    for (i = 0; i < 3; i++) cout << birth_to_obs[i] << " ";
     cout << endl;
     cout << "birth_to_obs dir_cosines = ";
-    for (i = 0; i < 3; i++)
-      cout << dir_cosines_birth_to_obs[i] << " ";
+    for (i = 0; i < 3; i++) cout << dir_cosines_birth_to_obs[i] << " ";
     cout << endl;
   }
 #endif
 
   // determine the optical depth to the surface from the birth site
   // towards the observer
-  for (i = 0; i < 3; i++)
-    photon.dir_cosines[i] = dir_cosines_birth_to_obs[i];
+  for (i = 0; i < 3; i++) photon.dir_cosines[i] = dir_cosines_birth_to_obs[i];
   double target_tau = 1e20;
-  double target_dist = 1e10*geometry.radius;
+  double target_dist = 1e10 * geometry.radius;
+  if (geometry.internal_observer == 1) target_tau = dist_birth_to_obs;
   int escape = 0;
   double tau_birth_to_obs = 0.0;
 
   // check that the direction to the observer will not force an
   // immediate exit from the grid, step back slightly to avoid this
   for (i = 0; i < 3; i++) {
-    if ((photon.dir_cosines[i] < 0.) && (photon.position[i] == geometry.grids[photon.current_grid_num].positions[i][0]))
-      photon.position[i] += 0.01*(geometry.grids[photon.current_grid_num].positions[i][1] -
-				  geometry.grids[photon.current_grid_num].positions[i][0]);
-    else if ((photon.dir_cosines[i] > 0.) && (photon.position[i] == geometry.grids[photon.current_grid_num].positions[i][geometry.grids[photon.current_grid_num].index_dim[i]]))
-      photon.position[i] -= 0.01*(geometry.grids[photon.current_grid_num].positions[i][geometry.grids[photon.current_grid_num].index_dim[i]] -
-				  geometry.grids[photon.current_grid_num].positions[i][geometry.grids[photon.current_grid_num].index_dim[i]-1]);
+    if ((photon.dir_cosines[i] < 0.) &&
+        (photon.position[i] ==
+         geometry.grids[photon.current_grid_num].positions[i][0]))
+      photon.position[i] +=
+          0.01 * (geometry.grids[photon.current_grid_num].positions[i][1] -
+                  geometry.grids[photon.current_grid_num].positions[i][0]);
+    else if ((photon.dir_cosines[i] > 0.) &&
+             (photon.position[i] ==
+              geometry.grids[photon.current_grid_num].positions
+                  [i][geometry.grids[photon.current_grid_num].index_dim[i]]))
+      photon.position[i] -=
+          0.01 *
+          (geometry.grids[photon.current_grid_num].positions
+               [i][geometry.grids[photon.current_grid_num].index_dim[i]] -
+           geometry.grids[photon.current_grid_num].positions
+               [i][geometry.grids[photon.current_grid_num].index_dim[i] - 1]);
   }
 
 #ifdef DEBUG_STWTO
@@ -73,17 +81,24 @@ double stellar_weight_towards_observer (photon_data photon,
     cout << "initial indexs done" << endl;
     cout << "num_current_grids = " << photon.num_current_grids << endl;
     cout << "current_grid_num = " << photon.current_grid_num << endl;
-    for (i = 0; i < 3; i++) cout << photon.position_index[photon.current_grid_num][i] << " ";
+    for (i = 0; i < 3; i++)
+      cout << photon.position_index[photon.current_grid_num][i] << " ";
     cout << endl;
-    int k =  photon.current_grid_num;
+    int k = photon.current_grid_num;
     int grid_val = photon.grid_number[k];
-    cout << geometry.grids[grid_val].grid(photon.position_index[k][0],photon.position_index[k][1],photon.position_index[k][2]).dust_tau_per_pc << endl;
+    cout << geometry.grids[grid_val]
+                .grid(photon.position_index[k][0], photon.position_index[k][1],
+                      photon.position_index[k][2])
+                .dust_tau_per_pc
+         << endl;
     cout << "done" << endl;
   }
 #endif
 
   double distance_traveled = 0.0;
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_birth_to_obs);
+  distance_traveled = calc_photon_trajectory(
+      photon, geometry, target_tau, target_dist, escape, tau_birth_to_obs);
+
 #ifdef DEBUG_STWTO
   if (photon.number == OUTNUM) {
     cout << "tau/distance traveled = " << tau_birth_to_obs << " ";
@@ -106,5 +121,5 @@ double stellar_weight_towards_observer (photon_data photon,
   // udpate stellar weight
   stellar_weight *= stellar_weight_tau;
 
-  return(stellar_weight);
+  return (stellar_weight);
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'DIRTY'
-copyright = '2018, Karl Gordon'
+copyright = '2023, Karl Gordon'
 author = 'Karl Gordon'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -83,8 +83,8 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
-html_theme = "sphinx_rtd_theme"
+html_theme = 'alabaster'
+# html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/pfile_geometry.rst
+++ b/docs/pfile_geometry.rst
@@ -14,22 +14,33 @@ In general, length units are in pc.
 Global Details
 ==============
 
-**distance=100.0  [0,1e38]**
-
-The distance to the model is specified in parsecs. It is important that the distance is large
-enough to make sure that the entire model grid is beyond the observer.
-
 **n_obs_angles=1 [1,100]**
 
-The number of observer angles is usually 1, but could be up to 100.
-If the number of observer angles is 1, then the single observer (theta,phi) position is input using:
+The number of observers.  This is usually 1, but could be up to 100 for the case of external observers.
+If the number of observer angles is 1, then the single observer position is input using:
+
+**internal_obs=1 [0, 1]**
+
+Type of observer, 0 = external, 1 = internal.
+
+The position of the observer is specified differently depending on the type of observer.
+
+Internal observer (units are pc):
+
+**obs_x=0. [-radius, +radius]**
+
+**obs_y=0. [-radius, +radius]**
+
+**obs_y=0. [-radius, +radius]**
+
+External obsever (units are degrees):
 
 **obs_theta=0. [0.,180.]**
 
 **obs_phi=0. [0.,360.]**
 
-where the angles are input in degrees.
-If the number of observer angles is larger than 1, then a file is used.
+If the number of observer angles is larger than 1 and external observers are specified, then a file is used.  Multiple 
+internal observers is not supported at this time.
 
 **obs_file=obs_pos.dat [any string]**
 
@@ -39,7 +50,14 @@ If the properties of an average line-of-sight are desired, then set:
 
 **randomize_observer=1**
 
-This has the effect of picking a new random observer theta/phi for each photon, averaging over all lines-of-sight.
+This has the effect of picking a new random observer theta/phi for each photon, averaging over all lines-of-sight.  Only
+applicable for external observers.
+
+**distance=100.0  [0,1e38]**
+
+The distance to the model is specified in parsecs. For external observers, it is important that the distance is large
+enough to make sure that the entire model grid is beyond the observer.  This parameter is not used in the case of an internal
+observer, but still must be present.
 
 Source Properties
 =================

--- a/docs/pfile_geometry.rst
+++ b/docs/pfile_geometry.rst
@@ -17,7 +17,6 @@ Global Details
 **n_obs_angles=1 [1,100]**
 
 The number of observers.  This is usually 1, but could be up to 100 for the case of external observers.
-If the number of observer angles is 1, then the single observer position is input using:
 
 **internal_obs=1 [0, 1]**
 

--- a/docs/pfile_run.rst
+++ b/docs/pfile_run.rst
@@ -70,7 +70,7 @@ For rectangular images.  This option may be particularly useful for internal obs
 For internal observers, the image is given in (phi, theta) angles.  Specifically the 
 x-axis=phi and y-axis=cos(theta).
 
-**output_filebase=redsg_lmc_T2800_R3200_test_time4 [any string]**
+**output_filebase=standard_sphere [any string]**
 
 The size base filename of the images.
 

--- a/docs/pfile_run.rst
+++ b/docs/pfile_run.rst
@@ -55,9 +55,20 @@ and emission (equilibrium/non-equilibrium).
 
 These are the images from the stellar radiative transfer before the dust emission.
 
+The size of the output images (at each wavelength) can be given two ways.
+
 **output_image_size=201 [1,5e4]**
 
-The size of the output images (at each wavelength).
+For square images.  Usually used for external observers where the output image is 
+a tangent projection.
+
+**output_image_x_size=201 [1,5e4]**
+
+**output_image_y_size=201 [1,5e4]**
+
+For rectangular images.  This option may be particularly useful for internal observers.
+For internal observers, the image is given in (phi, theta) angles.  Specifically the 
+x-axis=phi and y-axis=cos(theta).
 
 **output_filebase=redsg_lmc_T2800_R3200_test_time4 [any string]**
 

--- a/example/standard_sphere.param
+++ b/example/standard_sphere.param
@@ -34,7 +34,7 @@ albedo=0.6
 g=0.6
 
 [Run]
-num_photons=100000
+num_photons=10000
 output_image_size=201
 output_filebase=standard_sphere_tau1_test_target_dist
 # how to store the absorbed energy (speed vs RAM size)

--- a/example/standard_sphere.param
+++ b/example/standard_sphere.param
@@ -36,7 +36,7 @@ g=0.6
 [Run]
 num_photons=100000
 output_image_size=201
-output_filebase=standard_sphere_tau1
+output_filebase=standard_sphere_tau1_test_target_dist
 # how to store the absorbed energy (speed vs RAM size)
 # 0 to use memory, 1 to use disk
 abs_energy_storage=0

--- a/example/standard_sphere_internal_observer.param
+++ b/example/standard_sphere_internal_observer.param
@@ -6,8 +6,10 @@
 [Geometry]
 distance=100.0
 n_obs_angles=1
+#obs_theta=0.
+#obs_phi=0.
 internal_obs=1
-obs_x=0.0
+obs_x=0.5
 obs_y=0.0
 obs_z=0.0
 source_type=stars
@@ -21,9 +23,11 @@ radius=1.0
 tau=1.0
 # filling factor & density control the clumpiness
 filling_factor=0.05
-density_ratio=0.01
+#density_ratio=0.01
+density_ratio=1.0
 # this controls how to subdivide cells
-max_tau_per_cell=0.1
+max_tau_per_cell=10.0
+#max_tau_per_cell=0.1
 # spherical or cubical clumps [choices are sphere/cube]
 clump_type=cube
 # size of grid (all dimensions equal)
@@ -36,10 +40,13 @@ albedo=0.6
 g=0.6
 
 [Run]
-num_photons=10000
+num_photons=1000000
+#output_image_size=201
 output_image_x_size=201
 output_image_y_size=101
-output_filebase=standard_sphere_tau1_test_target_dist
+#output_filebase=standard_sphere_tau1_test_output_grid
+output_filebase=standard_sphere_tau1_test_internal_obs
+#output_filebase=standard_sphere_tau1_test_external_obs
 # how to store the absorbed energy (speed vs RAM size)
 # 0 to use memory, 1 to use disk
 abs_energy_storage=0

--- a/example/standard_sphere_internal_observer.param
+++ b/example/standard_sphere_internal_observer.param
@@ -7,7 +7,7 @@
 distance=100.0
 n_obs_angles=1
 internal_obs=1
-obs_x=0.5
+obs_x=0.0
 obs_y=0.0
 obs_z=0.0
 source_type=stars
@@ -21,9 +21,9 @@ radius=1.0
 tau=1.0
 # filling factor & density control the clumpiness
 filling_factor=0.05
-density_ratio=1.0
+density_ratio=0.01
 # this controls how to subdivide cells
-max_tau_per_cell=50.0
+max_tau_per_cell=0.1
 # spherical or cubical clumps [choices are sphere/cube]
 clump_type=cube
 # size of grid (all dimensions equal)
@@ -36,7 +36,7 @@ albedo=0.6
 g=0.6
 
 [Run]
-num_photons=1000000
+num_photons=10000
 output_image_x_size=201
 output_image_y_size=101
 output_filebase=standard_sphere_tau1_test_target_dist
@@ -44,4 +44,5 @@ output_filebase=standard_sphere_tau1_test_target_dist
 # 0 to use memory, 1 to use disk
 abs_energy_storage=0
 do_image_output=1
+output_model_grid=1
 verbose=1

--- a/example/standard_sphere_internal_observer.param
+++ b/example/standard_sphere_internal_observer.param
@@ -1,0 +1,47 @@
+# Test parameter file for DIRTY_v2
+#  created KDG 3 Jul 2006
+#  standard tau=1, constant density sphere
+#
+# Model parameters
+[Geometry]
+distance=100.0
+n_obs_angles=1
+internal_obs=1
+obs_x=0.5
+obs_y=0.0
+obs_z=0.0
+source_type=stars
+n_stars=1
+star_pos_x=-0.5
+star_pos_y=-0.5
+star_pos_z=-0.5
+type=sphere
+radius=1.0
+# radial optical depth
+tau=1.0
+# filling factor & density control the clumpiness
+filling_factor=0.05
+density_ratio=1.0
+# this controls how to subdivide cells
+max_tau_per_cell=50.0
+# spherical or cubical clumps [choices are sphere/cube]
+clump_type=cube
+# size of grid (all dimensions equal)
+grid_size=50
+
+[Dust Grains]
+type=single_wavelength
+wavelength=0.55
+albedo=0.6
+g=0.6
+
+[Run]
+num_photons=1000000
+output_image_x_size=201
+output_image_y_size=101
+output_filebase=standard_sphere_tau1_test_target_dist
+# how to store the absorbed energy (speed vs RAM size)
+# 0 to use memory, 1 to use disk
+abs_energy_storage=0
+do_image_output=1
+verbose=1

--- a/example/standard_sphere_offset_star.param
+++ b/example/standard_sphere_offset_star.param
@@ -1,0 +1,44 @@
+# Test parameter file for DIRTY_v2
+#  created KDG 3 Jul 2006
+#  standard tau=1, constant density sphere
+#
+# Model parameters
+[Geometry]
+distance=100.0
+n_obs_angles=1
+obs_theta=0.
+obs_phi=0.
+source_type=stars
+n_stars=1
+star_pos_x=-0.5
+star_pos_y=-0.5
+star_pos_z=-0.5
+type=sphere
+radius=1.0
+# radial optical depth
+tau=1.0
+# filling factor & density control the clumpiness
+filling_factor=0.05
+density_ratio=1.0
+# this controls how to subdivide cells
+max_tau_per_cell=50.0
+# spherical or cubical clumps [choices are sphere/cube]
+clump_type=cube
+# size of grid (all dimensions equal)
+grid_size=50
+
+[Dust Grains]
+type=single_wavelength
+wavelength=0.55
+albedo=0.6
+g=0.6
+
+[Run]
+num_photons=1000000
+output_image_size=201
+output_filebase=standard_sphere_offset_star_tau1
+# how to store the absorbed energy (speed vs RAM size)
+# 0 to use memory, 1 to use disk
+abs_energy_storage=0
+do_image_output=1
+verbose=1

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,0 @@
-conda:
-  file: .rtd-environment.yml


### PR DESCRIPTION
An internal observer is now an option.  The specifications for the internal observer are given in the parameter file.   See `standard_sphere_internal_observer.param` for an example.

The biggest change was adding a distance target to the photon trajectory calculation.  Now the photon will stop when it reaches the target distance *or* tau.  Other changes were needed to create the output images in spherical coordinates instead of a tangent projection.  The output image for the internal observer has dimensions of x = phi and y = cos(theta) and the origin (phi, theta) = (0, 0) is in the middle of the image.  I used cos(theta) for the y-axis instead of theta as this should capture the information more uniformly.  

The output image dimensions can now be specified for x and y independently.

Some formatting changes also included.   Will likely do a separate PR to reformat all the code to a common format (likely the Google recommended one).