### PR TITLE
Fixing incorrect documentation for reading arbitrary files

### DIFF
--- a/DIRTY/include/setup_dust_grid_file.h
+++ b/DIRTY/include/setup_dust_grid_file.h
@@ -21,7 +21,8 @@ extern int check_fits_io(int status,
 			 const char text[100]);
 
 extern void setup_dust_grid_check_grid (geometry_struct& geometry,
-					int cur_grid);
+					int cur_grid,
+					int par_grid);
 
 extern void setup_dust_grid_subdivide_overdense_cells (geometry_struct& geometry,
 						       int spherical_clumps);

--- a/DIRTY/setup_dust_grid_check_grid.cpp
+++ b/DIRTY/setup_dust_grid_check_grid.cpp
@@ -5,35 +5,44 @@
 // KDG Oct 2009 - written
 // ======================================================================
 #include "setup_dust_grid_check_grid.h"
-//#define DEBUG_SDGCG
+// #define DEBUG_SDGCG
 
-void setup_dust_grid_check_grid (geometry_struct& geometry,
-				 int cur_grid)
+void setup_dust_grid_check_grid(geometry_struct& geometry, int cur_grid,
+                                int par_grid)
 
 {
-  int i,j,k = 0;
+  int i, j, k = 0;
   float dust_tau_per_pc = 0.0;
 
-//   cout << "checking grid # = " << cur_grid << " ";
-//   cout << "out of " << geometry.grids.size() << " grids" << endl;
+  //   cout << "checking grid # = " << cur_grid << " ";
+  //   cout << "out of " << geometry.grids.size() << " grids" << endl;
+
+  // check the parent grid is correctly indicated
+  if (geometry.grids[cur_grid].parent_grid_num != par_grid) {
+	cout << "parent grid number set to " << geometry.grids[cur_grid].parent_grid_num;
+	cout << " but should be " << par_grid << endl;
+	cout << "for current grid index = " << cur_grid << endl;
+	exit(8);
+  }
 
   for (k = 0; k < geometry.grids[cur_grid].index_dim[2]; k++)
     for (j = 0; j < geometry.grids[cur_grid].index_dim[1]; j++) {
       for (i = 0; i < geometry.grids[cur_grid].index_dim[0]; i++) {
-	dust_tau_per_pc = geometry.grids[cur_grid].grid(i,j,k).dust_tau_per_pc;
-// 	cout << dust_tau_per_pc << " ";
-	if (dust_tau_per_pc < -0.5) {
-	  if (abs(dust_tau_per_pc) <= geometry.grids.size())
-	    setup_dust_grid_check_grid(geometry, abs(dust_tau_per_pc));
-	  else {
-	    cout << "subgrid # = " << abs(dust_tau_per_pc) << " does not exist." << endl;
-	    cout << "in grid # = " << cur_grid << endl;
-	    exit(8);
-	  }
-	}
-// 	cout << endl;
+        dust_tau_per_pc =
+            geometry.grids[cur_grid].grid(i, j, k).dust_tau_per_pc;
+        // 	cout << dust_tau_per_pc << " ";
+        if (dust_tau_per_pc < -0.5) {
+          if (abs(dust_tau_per_pc) <= geometry.grids.size())
+            setup_dust_grid_check_grid(geometry, abs(dust_tau_per_pc),
+                                       cur_grid);
+          else {
+            cout << "subgrid # = " << abs(dust_tau_per_pc) << " does not exist."
+                 << endl;
+            cout << "in grid # = " << cur_grid << endl;
+            exit(8);
+          }
+        }
+        // 	cout << endl;
       }
-	
-      }
-
+    }
 }

--- a/DIRTY/setup_dust_grid_file.cpp
+++ b/DIRTY/setup_dust_grid_file.cpp
@@ -5,53 +5,56 @@
 // KDG 6-7 Oct 2009 - major work
 // ======================================================================
 #include "setup_dust_grid_file.h"
-//#define DEBUG_SDGF
+// #define DEBUG_SDGF
 
-void setup_dust_grid_file (ConfigFile& param_data,
-			   geometry_struct& geometry)
+void setup_dust_grid_file(ConfigFile& param_data, geometry_struct& geometry)
 
 {
-
   // maximum optical depth per cell (controls when a cell is subdivided)
-  geometry.max_tau_per_cell = param_data.FValue("Geometry","max_tau_per_cell");
-  check_input_param("max_tau_per_cell",geometry.max_tau_per_cell,0.0,1e10);
+  geometry.max_tau_per_cell = param_data.FValue("Geometry", "max_tau_per_cell");
+  check_input_param("max_tau_per_cell", geometry.max_tau_per_cell, 0.0, 1e10);
   geometry.max_tau_per_cell_x = geometry.max_tau_per_cell;
   geometry.max_tau_per_cell_y = geometry.max_tau_per_cell;
   geometry.max_tau_per_cell_z = geometry.max_tau_per_cell;
 
   // get the filename of the position file
-  string pos_filename = param_data.SValue("Geometry","type_file_pos");
+  string pos_filename = param_data.SValue("Geometry", "type_file_pos");
   // check that the file exists
   ifstream pos_file(pos_filename.c_str());
   if (pos_file.fail()) {
-    cout << "Geometry position file (" << pos_filename << ") does not exist." << endl;
+    cout << "Geometry position file (" << pos_filename << ") does not exist."
+         << endl;
     exit(8);
   }
   pos_file.close();
 
   // get the filename of the tau/pc file
-  string tau_pc_filename = param_data.SValue("Geometry","type_file_tau_pc");
+  string tau_pc_filename = param_data.SValue("Geometry", "type_file_tau_pc");
   // check that the file exists
   ifstream tau_pc_file(tau_pc_filename.c_str());
   if (tau_pc_file.fail()) {
-    cout << "Geometry tau/pc file (" << tau_pc_filename << ") does not exist." << endl;
+    cout << "Geometry tau/pc file (" << tau_pc_filename << ") does not exist."
+         << endl;
     exit(8);
   }
   tau_pc_file.close();
-  
+
   // open the position and tau/pc files for reading
   int status = 0;
-  int hdutype = 0;   // type of header
-  fitsfile *pos_file_ptr;   // pointer to pos FITS file
-  fitsfile *tau_pc_file_ptr;  // pointer to tau/pc FITS file
-  
-  fits_open_file(&pos_file_ptr, pos_filename.c_str(), READONLY, &status);   // open the file
+  int hdutype = 0;            // type of header
+  fitsfile* pos_file_ptr;     // pointer to pos FITS file
+  fitsfile* tau_pc_file_ptr;  // pointer to tau/pc FITS file
+
+  fits_open_file(&pos_file_ptr, pos_filename.c_str(), READONLY,
+                 &status);  // open the file
   check_fits_io(status, "fits_open_file : pos_file");
 
-  fits_open_file(&tau_pc_file_ptr, tau_pc_filename.c_str(), READONLY, &status);   // open the file
+  fits_open_file(&tau_pc_file_ptr, tau_pc_filename.c_str(), READONLY,
+                 &status);  // open the file
   check_fits_io(status, "fits_open_file : tau_pc_file");
 
-  // determine the number of grids in the files (1 = main_grid, rest are subgrids)
+  // determine the number of grids in the files (1 = main_grid, rest are
+  // subgrids)
   int num_grids = 0;
   fits_get_num_hdus(pos_file_ptr, &num_grids, &status);
 
@@ -60,8 +63,10 @@ void setup_dust_grid_file (ConfigFile& param_data,
 
   // make sure the tau_pc file has the same number of grids
   if (num_grids != num_grids_tau) {
-    cout << "Number of grids in position and tau/pc files does not match" << endl;
-    cout << "# grids positon, tau = " << num_grids << ", " << num_grids_tau << endl;
+    cout << "Number of grids in position and tau/pc files does not match"
+         << endl;
+    cout << "# grids positon, tau = " << num_grids << ", " << num_grids_tau
+         << endl;
     exit(8);
   }
 
@@ -82,73 +87,80 @@ void setup_dust_grid_file (ConfigFile& param_data,
   // geometry.max_grid_depth
 
   // loop over the grids reading them into the necessary internal variables
-  int i,k,l,m = 0;
+  int i, k, l, m = 0;
 #ifdef DEBUG_SDGF
   cout << "num_grids = " << num_grids << endl;
 #endif
   for (i = 0; i < num_grids; i++) {
 #ifdef DEBUG_SDGF
-    cout << endl << "grid # = " << (i+1) << endl;
+    cout << endl << "grid # = " << (i + 1) << endl;
 #endif
 
     // declare grid
     one_grid subgrid;
 
     // get the size of the grid
-    fits_read_key(pos_file_ptr, TLONG, "NAXIS1", &pos_naxes[0], comment, &status);
-    fits_read_key(pos_file_ptr, TLONG, "NAXIS2", &pos_naxes[1], comment, &status);
+    fits_read_key(pos_file_ptr, TLONG, "NAXIS1", &pos_naxes[0], comment,
+                  &status);
+    fits_read_key(pos_file_ptr, TLONG, "NAXIS2", &pos_naxes[1], comment,
+                  &status);
     check_fits_io(status, "fits_read_key : pos_file naxes1&2");
 
     // get the detailed size of each dimension
-    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS1", &subgrid.index_dim[0], comment, &status);
-    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS2", &subgrid.index_dim[1], comment, &status);
-    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS3", &subgrid.index_dim[2], comment, &status);
+    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS1", &subgrid.index_dim[0],
+                  comment, &status);
+    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS2", &subgrid.index_dim[1],
+                  comment, &status);
+    fits_read_key(tau_pc_file_ptr, TLONG, "NAXIS3", &subgrid.index_dim[2],
+                  comment, &status);
     check_fits_io(status, "fits_read_key : tau_pc_file x,y,zsize");
 
     // check that the cube size is less than the positions
     if (!((subgrid.index_dim[0] < pos_naxes[0]) &&
-	  (subgrid.index_dim[1] < pos_naxes[0]) &&
-	  (subgrid.index_dim[2] < pos_naxes[0]))) {
-      cout << "At least one of the cube dimensions exceeds the position dimensions" << endl;
+          (subgrid.index_dim[1] < pos_naxes[0]) &&
+          (subgrid.index_dim[2] < pos_naxes[0]))) {
+      cout << "At least one of the cube dimensions exceeds the position "
+              "dimensions"
+           << endl;
       cout << "position dimension = " << pos_naxes[0] << endl;
       exit(8);
-      }
-      
+    }
+
     // create the position arrays
-    vector<double> x_pos(subgrid.index_dim[0]+1);
-    vector<double> y_pos(subgrid.index_dim[1]+1);
-    vector<double> z_pos(subgrid.index_dim[2]+1);
+    vector<double> x_pos(subgrid.index_dim[0] + 1);
+    vector<double> y_pos(subgrid.index_dim[1] + 1);
+    vector<double> z_pos(subgrid.index_dim[2] + 1);
 
     // read in the positions
     nulval = 0.0;
     anynul = 0;
     fpixel[0] = 1;
     fpixel[1] = 1;
-    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[0]+1, &nulval, &x_pos[0], &anynul, &status);
-    check_fits_io(status,"setup_dust_grid_file, fits_read_pix: pos[0]");
+    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[0] + 1,
+                  &nulval, &x_pos[0], &anynul, &status);
+    check_fits_io(status, "setup_dust_grid_file, fits_read_pix: pos[0]");
 #ifdef DEBUG_SDGF
-    for (k = 0; k < (subgrid.index_dim[1]+1); k++)
-      cout << x_pos[k] << " ";
+    for (k = 0; k < (subgrid.index_dim[1] + 1); k++) cout << x_pos[k] << " ";
     cout << endl;
 #endif
 
     fpixel[0] = 1;
     fpixel[1] = 2;
-    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[1]+1, &nulval, &y_pos[0], &anynul, &status);
-    check_fits_io(status,"setup_dust_grid_file, fits_read_pix: pos[1]");
+    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[1] + 1,
+                  &nulval, &y_pos[0], &anynul, &status);
+    check_fits_io(status, "setup_dust_grid_file, fits_read_pix: pos[1]");
 #ifdef DEBUG_SDGF
-    for (k = 0; k < (subgrid.index_dim[1]+1); k++)
-      cout << y_pos[k] << " ";
+    for (k = 0; k < (subgrid.index_dim[1] + 1); k++) cout << y_pos[k] << " ";
     cout << endl;
 #endif
 
     fpixel[0] = 1;
     fpixel[1] = 3;
-    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[2]+1, &nulval, &z_pos[0], &anynul, &status);
-    check_fits_io(status,"setup_dust_grid_file, fits_read_pix: pos[3]");
+    fits_read_pix(pos_file_ptr, TDOUBLE, &fpixel[0], subgrid.index_dim[2] + 1,
+                  &nulval, &z_pos[0], &anynul, &status);
+    check_fits_io(status, "setup_dust_grid_file, fits_read_pix: pos[3]");
 #ifdef DEBUG_SDGF
-    for (k = 0; k < (subgrid.index_dim[2]+1); k++)
-      cout << z_pos[k] << " ";
+    for (k = 0; k < (subgrid.index_dim[2] + 1); k++) cout << z_pos[k] << " ";
     cout << endl;
 #endif
 
@@ -162,8 +174,10 @@ void setup_dust_grid_file (ConfigFile& param_data,
     cout << "dim, size, cube size" << endl;
 #endif
     for (k = 0; k < 3; k++) {
-      subgrid.phys_grid_size[k] = subgrid.positions[k][subgrid.index_dim[k]] - subgrid.positions[k][0];
-      // subgrid.phys_cube_size[k] = subgrid.phys_grid_size[k]/subgrid.index_dim[k];
+      subgrid.phys_grid_size[k] =
+          subgrid.positions[k][subgrid.index_dim[k]] - subgrid.positions[k][0];
+      // subgrid.phys_cube_size[k] =
+      // subgrid.phys_grid_size[k]/subgrid.index_dim[k];
 #ifdef DEBUG_SDGF
       cout << k << " " << subgrid.phys_grid_size[k] << endl;
 #endif
@@ -171,11 +185,13 @@ void setup_dust_grid_file (ConfigFile& param_data,
 
     // determine useful quantities for geometry record
     if (i == 0) {
-      geometry.radius = subgrid.phys_grid_size[0]/2.;
+      geometry.radius = subgrid.phys_grid_size[0] / 2.;
       for (k = 1; k < 3; k++)
-	if (subgrid.phys_grid_size[k]/2. > geometry.radius) geometry.radius = subgrid.phys_grid_size[k]/2.;
+        if (subgrid.phys_grid_size[k] / 2. > geometry.radius)
+          geometry.radius = subgrid.phys_grid_size[k] / 2.;
 
-      geometry.angular_radius = atan(1.5*geometry.radius/(geometry.distance - geometry.radius));
+      geometry.angular_radius =
+          atan(1.5 * geometry.radius / (geometry.distance - geometry.radius));
 
 #ifdef DEBUG_SDGF
       cout << "radius [pc] = " << geometry.radius << endl;
@@ -183,75 +199,88 @@ void setup_dust_grid_file (ConfigFile& param_data,
 #endif
 
       geometry.tau = 0.0;
-      fits_read_key(tau_pc_file_ptr, TFLOAT, "RAD_TAU", &geometry.tau, comment, &status);
+      fits_read_key(tau_pc_file_ptr, TFLOAT, "RAD_TAU", &geometry.tau, comment,
+                    &status);
       if (status != 0) {
-	geometry.tau = 0.0;
-	status = 0;
+        geometry.tau = 0.0;
+        status = 0;
       }
-      check_input_param("arbitrary file: radial optical depth",geometry.tau,0.0,1000.);
+      check_input_param("arbitrary file: radial optical depth", geometry.tau,
+                        0.0, 1000.);
 
       // variables that are not used, but are written to an output FITS file
-      // need to be set to avoid bad float to string conversions in creating the FITS file
+      // need to be set to avoid bad float to string conversions in creating the
+      // FITS file
       geometry.density_ratio = 1.0;
       geometry.clump_densities[0] = 0.0;
       geometry.clump_densities[1] = 0.0;
 
       // max grid depth
-      fits_read_key(tau_pc_file_ptr, TLONG, "GRDDEPTH", &geometry.max_grid_depth, comment, &status);
+      fits_read_key(tau_pc_file_ptr, TLONG, "GRDDEPTH",
+                    &geometry.max_grid_depth, comment, &status);
       if (status != 0) {
-	if (num_grids == 1)
-	  geometry.max_grid_depth = 1;
-	else
-	  geometry.max_grid_depth = 2;
-	status = 0;
+        if (num_grids == 1)
+          geometry.max_grid_depth = 1;
+        else
+          geometry.max_grid_depth = 2;
+        status = 0;
       }
-      check_input_param("arbitrary file: max_grid_depth",geometry.tau,0.0,1e6);
+      check_input_param("arbitrary file: max_grid_depth", geometry.tau, 0.0,
+                        1e6);
     }
-    
+
     // now get the cube of tau/pc
     // create a 3d matrix to read the tau/pc cube into
     NumUtils::Cube<float> tmp_tau;
-    tmp_tau.CSize(subgrid.index_dim[0],subgrid.index_dim[1],subgrid.index_dim[2]);
+    tmp_tau.CSize(subgrid.index_dim[0], subgrid.index_dim[1],
+                  subgrid.index_dim[2]);
 
     cfpixel[0] = 1;
     cfpixel[1] = 1;
     cfpixel[2] = 1;
-    fits_read_pix(tau_pc_file_ptr, TFLOAT, &cfpixel[0], subgrid.index_dim[0]*subgrid.index_dim[1]*subgrid.index_dim[2], 
-		  &nulval, &tmp_tau[0], &anynul, &status);
-    check_fits_io(status,"setup_dust_grid_file, fits_read_pix: tau");
+    fits_read_pix(
+        tau_pc_file_ptr, TFLOAT, &cfpixel[0],
+        subgrid.index_dim[0] * subgrid.index_dim[1] * subgrid.index_dim[2],
+        &nulval, &tmp_tau[0], &anynul, &status);
+    check_fits_io(status, "setup_dust_grid_file, fits_read_pix: tau");
 #ifdef DEBUG_SDGF
     cout << "tau/pc along z-axis" << endl;
     for (k = 0; k < subgrid.index_dim[2]; k++)
-      cout << tmp_tau(int(subgrid.index_dim[2]/2),int(subgrid.index_dim[2]/2),k) << " ";
+      cout << tmp_tau(int(subgrid.index_dim[2] / 2),
+                      int(subgrid.index_dim[2] / 2), k)
+           << " ";
     cout << endl;
 #endif
     // allocate the grid cells
-    subgrid.grid.CSize(subgrid.index_dim[0],subgrid.index_dim[1],subgrid.index_dim[2]);
+    subgrid.grid.CSize(subgrid.index_dim[0], subgrid.index_dim[1],
+                       subgrid.index_dim[2]);
 
     // now loop over the grid and put the tau/pc into the grid cell
     for (k = 0; k < subgrid.index_dim[2]; k++)
       for (l = 0; l < subgrid.index_dim[1]; l++)
-	for (m = 0; m < subgrid.index_dim[0]; m++)
-	  subgrid.grid(m,l,k).dust_tau_per_pc = tmp_tau(m,l,k);
+        for (m = 0; m < subgrid.index_dim[0]; m++)
+          subgrid.grid(m, l, k).dust_tau_per_pc = tmp_tau(m, l, k);
 
     // identify the parent grid
     if (i == 0)
       subgrid.parent_grid_num = -1;
     else {
-      fits_read_key(tau_pc_file_ptr, TINT, "PAR_GRID", &subgrid.parent_grid_num, comment, &status);
-      check_fits_io(status, "fits_read_key : tau_pc_file parent_grid number (PAR_GRID)");
-      check_input_param("arbitrary file input: parent_grid number", subgrid.parent_grid_num, 0, (num_grids-1));
+      fits_read_key(tau_pc_file_ptr, TINT, "PAR_GRID", &subgrid.parent_grid_num,
+                    comment, &status);
+      check_fits_io(
+          status, "fits_read_key : tau_pc_file parent_grid number (PAR_GRID)");
+      check_input_param("arbitrary file input: parent_grid number",
+                        subgrid.parent_grid_num, 0, (num_grids - 1));
     }
-    
+
     geometry.grids.push_back(subgrid);
 
     // move to the next subgrid, unless we are at the end
-    if (i < (num_grids-1)) {
+    if (i < (num_grids - 1)) {
       fits_movrel_hdu(pos_file_ptr, 1, &hdutype, &status);
       fits_movrel_hdu(tau_pc_file_ptr, 1, &hdutype, &status);
       check_fits_io(status, "fits_movrel_hdu: pos & tau_pc files");
     }
-    
   }
 
   // close both files
@@ -261,11 +290,9 @@ void setup_dust_grid_file (ConfigFile& param_data,
   check_fits_io(status, "fits_close_file : tau_pc_file");
 
   // check to make sure that all subgrids designated exist
-  if (num_grids > 1)
-    setup_dust_grid_check_grid (geometry, 0);
+  if (num_grids > 1) setup_dust_grid_check_grid(geometry, 0, -1);
 
   int spherical_clumps = 0;
   // subdivide all overdense cells
   setup_dust_grid_subdivide_overdense_cells(geometry, spherical_clumps);
-
 }

--- a/DIRTY/setup_dust_grid_subdivide_overdense_cells.cpp
+++ b/DIRTY/setup_dust_grid_subdivide_overdense_cells.cpp
@@ -2,190 +2,224 @@
 // Subdivide overdense cells in the grid
 //
 // KDG 15 May 2008 - Written (taken from setup_dust_grid_shell)
-// KDG 16 Jun 2008 - fixed max_grid_depth calculation & fixed assignment of grid number to parent
-// KDG 14 Jul 2008 - fixed error of interating over recently created subgrids
-// KDG 17 Jun 2015 - modified code to all for different subdivision for different axes
+// KDG 16 Jun 2008 - fixed max_grid_depth calculation & fixed assignment of grid
+// number to parent KDG 14 Jul 2008 - fixed error of interating over recently
+// created subgrids KDG 17 Jun 2015 - modified code to all for different
+// subdivision for different axes
 // ======================================================================
 #include "setup_dust_grid_subdivide_overdense_cells.h"
-//#define DEBUG_SDGSOC
+// #define DEBUG_SDGSOC
 
-void setup_dust_grid_subdivide_overdense_cells (geometry_struct& geometry,
-						int spherical_clumps)
+void setup_dust_grid_subdivide_overdense_cells(geometry_struct& geometry,
+                                               int spherical_clumps)
 
 {
-  int i,j,k,m = 0;
+  int i, j, k, m = 0;
 
   // loop over all existing grids and subgrid any overdense cells
   float x_tau, y_tau, z_tau = 0.0;
   int cur_subgrid_num = int(geometry.grids.size());
   int subdivide = 0;
   int subdivide_any = 0;
-  
+
   geometry.num_cells = 0;
- 
+
   long num_cells_orig = 0;
   long num_cells_subdivide = 0;
-  
+
   int n_grids = int(geometry.grids.size());
   for (m = 0; m < n_grids; m++) {
-
     for (k = 0; k < geometry.grids[m].index_dim[2]; k++)
       for (j = 0; j < geometry.grids[m].index_dim[1]; j++)
-	for (i = 0; i < geometry.grids[m].index_dim[0]; i++) {
-	  num_cells_orig++;
+        for (i = 0; i < geometry.grids[m].index_dim[0]; i++) {
+          num_cells_orig++;
 
-	  x_tau = (geometry.grids[m].positions[0][i+1] - geometry.grids[m].positions[0][i])*
-	    geometry.grids[m].grid(i,j,k).dust_tau_per_pc;
-	  y_tau = (geometry.grids[m].positions[1][j+1] - geometry.grids[m].positions[1][j])*
-	    geometry.grids[m].grid(i,j,k).dust_tau_per_pc;
-	  z_tau = (geometry.grids[m].positions[2][k+1] - geometry.grids[m].positions[2][k])*
-	    geometry.grids[m].grid(i,j,k).dust_tau_per_pc;
+          x_tau = (geometry.grids[m].positions[0][i + 1] -
+                   geometry.grids[m].positions[0][i]) *
+                  geometry.grids[m].grid(i, j, k).dust_tau_per_pc;
+          y_tau = (geometry.grids[m].positions[1][j + 1] -
+                   geometry.grids[m].positions[1][j]) *
+                  geometry.grids[m].grid(i, j, k).dust_tau_per_pc;
+          z_tau = (geometry.grids[m].positions[2][k + 1] -
+                   geometry.grids[m].positions[2][k]) *
+                  geometry.grids[m].grid(i, j, k).dust_tau_per_pc;
 
-	  subdivide = 0;
-	  if (x_tau > geometry.max_tau_per_cell_x) subdivide = 1;
-	  if (y_tau > geometry.max_tau_per_cell_y) subdivide = 1;
-	  if (z_tau > geometry.max_tau_per_cell_z) subdivide = 1;
-	  if ((spherical_clumps) && (geometry.grids[0].grid(i,j,k).dust_tau_per_pc == geometry.clump_densities[0])) subdivide = 1;
+          subdivide = 0;
+          if (x_tau > geometry.max_tau_per_cell_x) subdivide = 1;
+          if (y_tau > geometry.max_tau_per_cell_y) subdivide = 1;
+          if (z_tau > geometry.max_tau_per_cell_z) subdivide = 1;
+          if ((spherical_clumps) &&
+              (geometry.grids[0].grid(i, j, k).dust_tau_per_pc ==
+               geometry.clump_densities[0]))
+            subdivide = 1;
 
-	  if (subdivide) {
-	    num_cells_subdivide++;
+          if (subdivide) {
+            num_cells_subdivide++;
 
 #ifdef DEBUG_SDGSOC
-	    cout << m << ",";
-	    cout << i << ",";
-	    cout << j << ",";
-	    cout << k << " needs a subgrid; ";
+            cout << m << ",";
+            cout << i << ",";
+            cout << j << ",";
+            cout << k << " needs a subgrid; ";
             cout << "max_tau_x = " << geometry.max_tau_per_cell_x << endl;
-	    cout << "cell tau_x = " << x_tau << endl;
+            cout << "cell tau_x = " << x_tau << endl;
 #endif
-	    
-	    // note that we've subdivided at least one grid cel
-	    subdivide_any = 1;
 
-	    one_grid subgrid;
-	    if (spherical_clumps) {
-	      subgrid.index_dim[0] = 10;  // make a sphere
-	      subgrid.index_dim[1] = subgrid.index_dim[0];
-	      subgrid.index_dim[2] = subgrid.index_dim[0];
-	    } else {
-	      if (x_tau > geometry.max_tau_per_cell_x) 
-		subgrid.index_dim[0] = int(x_tau/float(geometry.max_tau_per_cell_x)) + 1;
-	      else
-		subgrid.index_dim[0] = 1;
-	      if (y_tau > geometry.max_tau_per_cell_y) 
-		subgrid.index_dim[1] = int(y_tau/float(geometry.max_tau_per_cell_y)) + 1;
-	      else
-		subgrid.index_dim[1] = 1;
-	      if (z_tau > geometry.max_tau_per_cell_z) 
-		subgrid.index_dim[2] = int(z_tau/float(geometry.max_tau_per_cell_z)) + 1;
-	      else
-		subgrid.index_dim[2] = 1;
+            // note that we've subdivided at least one grid cel
+            subdivide_any = 1;
 
-//  	      cout << x_tau/float(geometry.max_tau_per_cell_x) << " ";
-// 	      cout << y_tau/float(geometry.max_tau_per_cell_y) << " ";
-// 	      cout << z_tau/float(geometry.max_tau_per_cell_z) << endl;
+            one_grid subgrid;
+            if (spherical_clumps) {
+              subgrid.index_dim[0] = 10;  // make a sphere
+              subgrid.index_dim[1] = subgrid.index_dim[0];
+              subgrid.index_dim[2] = subgrid.index_dim[0];
+            } else {
+              if (x_tau > geometry.max_tau_per_cell_x)
+                subgrid.index_dim[0] =
+                    int(x_tau / float(geometry.max_tau_per_cell_x)) + 1;
+              else
+                subgrid.index_dim[0] = 1;
+              if (y_tau > geometry.max_tau_per_cell_y)
+                subgrid.index_dim[1] =
+                    int(y_tau / float(geometry.max_tau_per_cell_y)) + 1;
+              else
+                subgrid.index_dim[1] = 1;
+              if (z_tau > geometry.max_tau_per_cell_z)
+                subgrid.index_dim[2] =
+                    int(z_tau / float(geometry.max_tau_per_cell_z)) + 1;
+              else
+                subgrid.index_dim[2] = 1;
 
-//  	      cout << int(x_tau/float(geometry.max_tau_per_cell_x)) << " ";
-// 	      cout << int(y_tau/float(geometry.max_tau_per_cell_y)) << " ";
-// 	      cout << int(z_tau/float(geometry.max_tau_per_cell_z)) << endl;
+              //  	      cout << x_tau/float(geometry.max_tau_per_cell_x)
+              //  << " ";
+              // 	      cout << y_tau/float(geometry.max_tau_per_cell_y)
+              // << " "; 	      cout << z_tau/float(geometry.max_tau_per_cell_z) <<
+              // endl;
 
-// 	      cout << subgrid.index_dim[0] << " ";
-// 	      cout << subgrid.index_dim[1] << " ";
-// 	      cout << subgrid.index_dim[2] << endl;
+              //  	      cout <<
+              //  int(x_tau/float(geometry.max_tau_per_cell_x)) << " ";
+              // 	      cout <<
+              // int(y_tau/float(geometry.max_tau_per_cell_y)) << " "; 	      cout <<
+              // int(z_tau/float(geometry.max_tau_per_cell_z)) << endl;
 
-// 	      cout << x_tau << " ";
-// 	      cout << y_tau << " ";
-// 	      cout << z_tau << endl;
+              // 	      cout << subgrid.index_dim[0] << " ";
+              // 	      cout << subgrid.index_dim[1] << " ";
+              // 	      cout << subgrid.index_dim[2] << endl;
 
-// 	      cout << geometry.max_tau_per_cell_x << " ";
-// 	      cout << geometry.max_tau_per_cell_y << " ";
-// 	      cout << geometry.max_tau_per_cell_z << endl;
-// 	      exit(8);
-	    }
-	    
-	    vector<double> x_subpos(subgrid.index_dim[0]+1);
-	    vector<double> y_subpos(subgrid.index_dim[1]+1);
-	    vector<double> z_subpos(subgrid.index_dim[2]+1);
-	    
-	    subgrid.phys_grid_size[0] = geometry.grids[m].positions[0][i+1] - geometry.grids[m].positions[0][i];
-	    subgrid.phys_grid_size[1] = geometry.grids[m].positions[1][j+1] - geometry.grids[m].positions[1][j];
-	    subgrid.phys_grid_size[2] = geometry.grids[m].positions[2][k+1] - geometry.grids[m].positions[2][k];
-	    
-	    // subgrid.phys_cube_size[0] = subgrid.phys_grid_size[0]/subgrid.index_dim[0];
-	    // subgrid.phys_cube_size[1] = subgrid.phys_grid_size[1]/subgrid.index_dim[1];
-	    // subgrid.phys_cube_size[2] = subgrid.phys_grid_size[2]/subgrid.index_dim[2];
+              // 	      cout << x_tau << " ";
+              // 	      cout << y_tau << " ";
+              // 	      cout << z_tau << endl;
 
-	    int l;
-	    // ensure that the first position exactly equals the edge of the parent cell
-	    //   no roundoff error problems (hopefully)
-	    x_subpos[0] = geometry.grids[m].positions[0][i];
-	    y_subpos[0] = geometry.grids[m].positions[1][j];
-	    z_subpos[0] = geometry.grids[m].positions[2][k];
-	    
-	    for (l = 1; l < subgrid.index_dim[0]; l++)
-	      x_subpos[l] = geometry.grids[m].positions[0][i] + (double(l)/subgrid.index_dim[0])*subgrid.phys_grid_size[0];
-	    
-	    for (l = 1; l < subgrid.index_dim[1]; l++)
-	      y_subpos[l] = geometry.grids[m].positions[1][j] + (double(l)/subgrid.index_dim[1])*subgrid.phys_grid_size[1];
-	    
-	    for (l = 1; l < subgrid.index_dim[2]; l++)
-	      z_subpos[l] = geometry.grids[m].positions[2][k] + (double(l)/subgrid.index_dim[2])*subgrid.phys_grid_size[2];
-	    
-	    // ensure that the last position exactly equals the edge of the parent cell
-	    //   no roundoff error problems (hopefully)
-	    x_subpos[subgrid.index_dim[0]] = geometry.grids[m].positions[0][i+1];
-	    y_subpos[subgrid.index_dim[1]] = geometry.grids[m].positions[1][j+1];
-	    z_subpos[subgrid.index_dim[2]] = geometry.grids[m].positions[2][k+1];
-	    
-	    subgrid.positions.push_back(x_subpos);
-	    subgrid.positions.push_back(y_subpos);
-	    subgrid.positions.push_back(z_subpos);
-	    
-	    subgrid.grid.CSize(subgrid.index_dim[0],subgrid.index_dim[1],subgrid.index_dim[2]);
+              // 	      cout << geometry.max_tau_per_cell_x << " ";
+              // 	      cout << geometry.max_tau_per_cell_y << " ";
+              // 	      cout << geometry.max_tau_per_cell_z << endl;
+              // 	      exit(8);
+            }
 
-	    float dust_tau_per_pc = geometry.grids[m].grid(i,j,k).dust_tau_per_pc;
-	    float index_radius;  // radius of subgrid position in index values
-	    int n,o;
-	    for (o = 0; o < subgrid.index_dim[2]; o++) 
-	      for (n = 0; n < subgrid.index_dim[1]; n++) 
-		for (l = 0; l < subgrid.index_dim[0]; l++) {
-		  geometry.num_cells++;
-		  if (spherical_clumps) {
-		    index_radius = sqrt(pow(float(o) - subgrid.index_dim[2]/2.,2.0) + 
-					pow(float(n) - subgrid.index_dim[1]/2.,2.0) +
-					pow(float(l) - subgrid.index_dim[0]/2.,2.0));
-		    if (index_radius < subgrid.index_dim[0]/2.)
-		      subgrid.grid(l,n,o).dust_tau_per_pc = dust_tau_per_pc;
-		    else
-		      subgrid.grid(l,n,o).dust_tau_per_pc = dust_tau_per_pc*geometry.density_ratio;
-		  } else {
-		    subgrid.grid(l,n,o).dust_tau_per_pc = dust_tau_per_pc;
-		  }
-		}
+            vector<double> x_subpos(subgrid.index_dim[0] + 1);
+            vector<double> y_subpos(subgrid.index_dim[1] + 1);
+            vector<double> z_subpos(subgrid.index_dim[2] + 1);
 
-	    // setup ties to parent grid
-	    subgrid.parent_grid_num = m;
-	    geometry.grids[m].grid(i,j,k).dust_tau_per_pc = -cur_subgrid_num;
-	    cur_subgrid_num++;
+            subgrid.phys_grid_size[0] = geometry.grids[m].positions[0][i + 1] -
+                                        geometry.grids[m].positions[0][i];
+            subgrid.phys_grid_size[1] = geometry.grids[m].positions[1][j + 1] -
+                                        geometry.grids[m].positions[1][j];
+            subgrid.phys_grid_size[2] = geometry.grids[m].positions[2][k + 1] -
+                                        geometry.grids[m].positions[2][k];
 
-	    geometry.grids.push_back(subgrid);
-	  } else {
-	    geometry.num_cells++;
-	    // calculate number of H atoms
-// 	    if (geometry.grids[m].grid(i,j,k).dust_tau_per_pc > 0.0)
-// 	      geometry.grids[m].grid(i,j,k).num_H = num_H_const*vol*geometry.grids[m].grid(i,j,k).dust_tau_per_pc*geometry.tau_to_tau_ref;
-// 	    else
-	    geometry.grids[m].grid(i,j,k).num_H = 0.0;
-	  }
-	}
+            // subgrid.phys_cube_size[0] =
+            // subgrid.phys_grid_size[0]/subgrid.index_dim[0];
+            // subgrid.phys_cube_size[1] =
+            // subgrid.phys_grid_size[1]/subgrid.index_dim[1];
+            // subgrid.phys_cube_size[2] =
+            // subgrid.phys_grid_size[2]/subgrid.index_dim[2];
+
+            int l;
+            // ensure that the first position exactly equals the edge of the
+            // parent cell
+            //   no roundoff error problems (hopefully)
+            x_subpos[0] = geometry.grids[m].positions[0][i];
+            y_subpos[0] = geometry.grids[m].positions[1][j];
+            z_subpos[0] = geometry.grids[m].positions[2][k];
+
+            for (l = 1; l < subgrid.index_dim[0]; l++)
+              x_subpos[l] = geometry.grids[m].positions[0][i] +
+                            (double(l) / subgrid.index_dim[0]) *
+                                subgrid.phys_grid_size[0];
+
+            for (l = 1; l < subgrid.index_dim[1]; l++)
+              y_subpos[l] = geometry.grids[m].positions[1][j] +
+                            (double(l) / subgrid.index_dim[1]) *
+                                subgrid.phys_grid_size[1];
+
+            for (l = 1; l < subgrid.index_dim[2]; l++)
+              z_subpos[l] = geometry.grids[m].positions[2][k] +
+                            (double(l) / subgrid.index_dim[2]) *
+                                subgrid.phys_grid_size[2];
+
+            // ensure that the last position exactly equals the edge of the
+            // parent cell
+            //   no roundoff error problems (hopefully)
+            x_subpos[subgrid.index_dim[0]] =
+                geometry.grids[m].positions[0][i + 1];
+            y_subpos[subgrid.index_dim[1]] =
+                geometry.grids[m].positions[1][j + 1];
+            z_subpos[subgrid.index_dim[2]] =
+                geometry.grids[m].positions[2][k + 1];
+
+            subgrid.positions.push_back(x_subpos);
+            subgrid.positions.push_back(y_subpos);
+            subgrid.positions.push_back(z_subpos);
+
+            subgrid.grid.CSize(subgrid.index_dim[0], subgrid.index_dim[1],
+                               subgrid.index_dim[2]);
+
+            float dust_tau_per_pc =
+                geometry.grids[m].grid(i, j, k).dust_tau_per_pc;
+            float index_radius;  // radius of subgrid position in index values
+            int n, o;
+            for (o = 0; o < subgrid.index_dim[2]; o++)
+              for (n = 0; n < subgrid.index_dim[1]; n++)
+                for (l = 0; l < subgrid.index_dim[0]; l++) {
+                  geometry.num_cells++;
+                  if (spherical_clumps) {
+                    index_radius =
+                        sqrt(pow(float(o) - subgrid.index_dim[2] / 2., 2.0) +
+                             pow(float(n) - subgrid.index_dim[1] / 2., 2.0) +
+                             pow(float(l) - subgrid.index_dim[0] / 2., 2.0));
+                    if (index_radius < subgrid.index_dim[0] / 2.)
+                      subgrid.grid(l, n, o).dust_tau_per_pc = dust_tau_per_pc;
+                    else
+                      subgrid.grid(l, n, o).dust_tau_per_pc =
+                          dust_tau_per_pc * geometry.density_ratio;
+                  } else {
+                    subgrid.grid(l, n, o).dust_tau_per_pc = dust_tau_per_pc;
+                  }
+                }
+
+            // setup ties to parent grid
+            subgrid.parent_grid_num = m;
+            geometry.grids[m].grid(i, j, k).dust_tau_per_pc = -cur_subgrid_num;
+            cur_subgrid_num++;
+
+            geometry.grids.push_back(subgrid);
+          } else {
+            geometry.num_cells++;
+            // calculate number of H atoms
+            // 	    if (geometry.grids[m].grid(i,j,k).dust_tau_per_pc > 0.0)
+            // 	      geometry.grids[m].grid(i,j,k).num_H =
+            // num_H_const*vol*geometry.grids[m].grid(i,j,k).dust_tau_per_pc*geometry.tau_to_tau_ref;
+            // 	    else
+            geometry.grids[m].grid(i, j, k).num_H = 0.0;
+          }
+        }
   }
 
-  if (subdivide_any)
-    geometry.max_grid_depth++;
+  if (subdivide_any) geometry.max_grid_depth++;
 
+  cout << "Result of optional subdivide overdense cells" << endl;
   cout << "total number of cells = " << geometry.num_cells << endl;
-  cout << "number of orig. cells = " << num_cells_orig << endl;
-  cout << "number of subdiv. cells = " << num_cells_subdivide << endl;
-
+  cout << "number of orig cells = " << num_cells_orig << endl;
+  cout << "number of orig subdiv cells = " << n_grids << endl;
+  cout << "number of new subdiv cells = " << num_cells_subdivide << endl;
 }
-

--- a/docs/pfile_geometry.rst
+++ b/docs/pfile_geometry.rst
@@ -265,12 +265,12 @@ cells would be "GRDDEPTH" = 3, etc.).
 
 For subgrids, the cell in the main grid that the subgrid is subdividing
 should be filled with the negative of the subgrid number (e.g., the 1st
-subgrid is numbered 2 and the cell in the main grid should have a value
-of -2, the 2nd subgrid is numbered 3 and the cell in the main grid has
-a value of -3, etc.). In addition, the header of each subgrid should
+subgrid is numbered 1 and the cell in the main grid should have a value
+of -1, the 2nd subgrid is numbered 2 and the cell in the main grid has
+a value of -2, etc.). In addition, the header of each subgrid should
 include the INT (datatype) keyword "PAR_GRID" with the index of the of
 the grid where of the cell it subdivides (e.g., subgrids of cells in
-the main grid will have "PAR_GRID" = 1).
+the main grid will have "PAR_GRID" = 0).
 
 A grid tau_ref_per_pc value of -0.5 designates that grid cells outside
 of this one are also filled with -0.5 and the model effectively stops

--- a/example/standard_sphere_internal_observer.param
+++ b/example/standard_sphere_internal_observer.param
@@ -22,12 +22,12 @@ radius=1.0
 # radial optical depth
 tau=1.0
 # filling factor & density control the clumpiness
-filling_factor=0.05
-#density_ratio=0.01
-density_ratio=1.0
+filling_factor=0.005
+density_ratio=0.01
+#density_ratio=1.0
 # this controls how to subdivide cells
-max_tau_per_cell=10.0
-#max_tau_per_cell=0.1
+#max_tau_per_cell=10.0
+max_tau_per_cell=0.1
 # spherical or cubical clumps [choices are sphere/cube]
 clump_type=cube
 # size of grid (all dimensions equal)
@@ -44,8 +44,8 @@ num_photons=1000000
 #output_image_size=201
 output_image_x_size=201
 output_image_y_size=101
-#output_filebase=standard_sphere_tau1_test_output_grid
-output_filebase=standard_sphere_tau1_test_internal_obs
+output_filebase=standard_sphere_tau1_test_output_grid
+#output_filebase=standard_sphere_tau1_test_internal_obs
 #output_filebase=standard_sphere_tau1_test_external_obs
 # how to store the absorbed energy (speed vs RAM size)
 # 0 to use memory, 1 to use disk


### PR DESCRIPTION
The docs stated the PAR_GRID should be set to 1 for the main grid.  It should be 0.  In addition, the 1st subdivided grid should have an index of 1, so a value of -1 in the main grid cell.  This was incorrectly set to 2 and -2 in the docs.  This PR corrects the docs.

In addition, the output from the optional subdivide overdense cells routine has been enhanced to make it clear what this subroutine is doing and reporting.  And the checking of reading arbitrary grids from FITS files has been enhanced to check the parent grid index is correct.  Finally, some of the files have been reformatted to make the indentation clearer.

Thanks to @hvbish and @catherinezucker for pointing out the error in the docs.