### PR TITLE
fix bug in output of radiation field nphotons

### DIFF
--- a/DIRTY/include/grid_cell.h
+++ b/DIRTY/include/grid_cell.h
@@ -5,7 +5,7 @@
 // 2007 Mar/KDG - changed absorbed energy from float to double
 // 2008 Mar/KDG - added num_H to save the number of H atoms per cell
 // 2008 Jun/KDG - made save_radiation_field_density into a vector to
-//                to properly handle the interations needed for dust self-absorption.
+//                to properly handle the interactions needed for dust self-absorption.
 // 2009 Dec/KDG - added sum of squared quantities to allow for uncertainties
 // ======================================================================
 #ifndef _DIRTY_GRID_CELL_

--- a/DIRTY/output_model_grid.cpp
+++ b/DIRTY/output_model_grid.cpp
@@ -88,7 +88,7 @@ void output_model_grid (geometry_struct& geometry,
     tmp_rad_field_unc.FVSize(geometry.grids[m].index_dim[0],geometry.grids[m].index_dim[1],geometry.grids[m].index_dim[2],n_waves);
 
     // create a 4d matrix to copy the grid info into for output
-    NumUtils::FourVector<int> tmp_rad_field_npts;
+    NumUtils::FourVector<short int> tmp_rad_field_npts;
     tmp_rad_field_npts.FVSize(geometry.grids[m].index_dim[0],geometry.grids[m].index_dim[1],geometry.grids[m].index_dim[2],n_waves);
 
     // create a 3d matrix to copy the grid info into for output


### PR DESCRIPTION
Weird nphotons output traced to C++ variable being and `int` instead of a `short int`.  Using `short int` and `TSHORT`/`16` in the FITS creation means the file is a factor of 2 smaller.