### PR TITLE
Add scaling for radiation field when a and g set

### DIFF
--- a/DIRTY/get_dust_parameters.cpp
+++ b/DIRTY/get_dust_parameters.cpp
@@ -39,9 +39,11 @@ void get_dust_parameters (ConfigFile& param_data,
     // set the tau_to_tau_ref value to 1.
     runinfo.tau_to_tau_ref.push_back(1.);
 
-    // set the grain info we won't have or really use
+    // set the grain info to have have the correction scaling
+    // here we have effectively set Cext = 1.0, 
+    //    hence Cabs = (1-albedo)Cext = (1-albedo)
     runinfo.tau_to_h.push_back(1.0);
-    runinfo.ave_C_abs.push_back(1.);
+    runinfo.ave_C_abs.push_back(1. - albedo);
 
 		// check that if a single wavlength run is picked, then do_global_output is not
 		if (runinfo.do_global_output) {

--- a/DIRTY/store_absorbed_energy_grid.cpp
+++ b/DIRTY/store_absorbed_energy_grid.cpp
@@ -114,9 +114,9 @@ void store_absorbed_energy_grid (geometry_struct& geometry,
 	    double flux_mult_factor = 0.0;
 	    if (doing_emission)
 	      if (runinfo.dust_thermal_emission)
-		flux_mult_factor = (runinfo.emitted_lum[0][index]/output.outputs[0].total_num_photons);
+			flux_mult_factor = (runinfo.emitted_lum[0][index]/output.outputs[0].total_num_photons);
 	      else
-		flux_mult_factor = (runinfo.emitted_ere_lum[0][index]/output.outputs[0].total_num_photons);
+			flux_mult_factor = (runinfo.emitted_ere_lum[0][index]/output.outputs[0].total_num_photons);
 	    else
 	      flux_mult_factor = (runinfo.sed_lum[index]/output.outputs[0].total_num_photons);
 


### PR DESCRIPTION
When the radiation field is desired for the case where the albedo and scattering phase function are set explicitly, the the radiation field should scale with 1/(1 - albedo).  Usually, the radiation field is computed for dust emission calculations where as dust grain model sets the values of tau/N(H), Cabs, albedo, and scattering phase function.  For the case where a and g are set explicitly, tau/N(HI) is set to 1 and Cabs should be set to 1-albedo (previously it was set to 1).  Cabs=(1-albedo)Cext and Cext=1 effectively in this case.