### PR TITLE
Repeating boundary condition in xy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ dirty
 docs/_build
 *.fits
 write_grain/*/*.dat
+stock_dirty
+.vscode
+Dust
+*.png
+*.drt
 
 # autotools
 .version

--- a/DIRTY/calc_delta_dist.cpp
+++ b/DIRTY/calc_delta_dist.cpp
@@ -10,26 +10,29 @@
 #define OUTNUM 33
 // #define DEBUG_CDD
 
-double calc_delta_dist (photon_data& photon,
-			geometry_struct& geometry,
-			double target_tau,
-			double target_dist,
-			int& escape,
-			double& tau_traveled)
+double calc_delta_dist(photon_data& photon, geometry_struct& geometry,
+                       double target_tau, double target_dist, int& escape,
+                       double& tau_traveled)
 
 {
 #ifdef DEBUG_CDD
   if (photon.number == OUTNUM) {
     cout << "starting cdd.." << endl;
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nRow()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nCol()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.n3rd()
+         << endl;
     cout << "photon.path_cur_cells = " << photon.path_cur_cells << endl;
   }
 #endif
   tau_traveled = 0.0;
   double distance_traveled = 0.0;  // resulting distance traveled
-  int exit_cell = 1;  // tells if the cell has been exited
+  int exit_cell = 1;               // tells if the cell has been exited
   int min_index = 0;
 
   // save the current grid number, the grid number, and the dust_tau_per_pc
@@ -45,14 +48,24 @@ double calc_delta_dist (photon_data& photon,
     cout << photon.position_index[k][0] << endl;
     cout << photon.position_index[k][1] << endl;
     cout << photon.position_index[k][2] << endl;
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nRow()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nCol()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.n3rd()
+         << endl;
     cout << "end testing" << endl;
   }
 #endif
-  double dust_tau_ref_per_pc = geometry.grids[grid_val].grid(photon.position_index[k][0],photon.position_index[k][1],photon.position_index[k][2]).dust_tau_per_pc;
-  double dust_tau_per_pc = dust_tau_ref_per_pc*geometry.tau_to_tau_ref;
+  double dust_tau_ref_per_pc =
+      geometry.grids[grid_val]
+          .grid(photon.position_index[k][0], photon.position_index[k][1],
+                photon.position_index[k][2])
+          .dust_tau_per_pc;
+  double dust_tau_per_pc = dust_tau_ref_per_pc * geometry.tau_to_tau_ref;
 
   // print the photon statistics
 #ifdef DEBUG_CDD
@@ -62,66 +75,82 @@ double calc_delta_dist (photon_data& photon,
     cout << "cdd photon in" << endl;
     cout << "number = " << photon.number << endl;
     cout << "pos = ";
-    for (di = 0; di < 3; di++)
-      cout << photon.position[di] << " ";
+    for (di = 0; di < 3; di++) cout << photon.position[di] << " ";
     cout << endl;
     cout << "dir_cos = ";
-    for (di = 0; di < 3; di++)
-      cout << photon.dir_cosines[di] << " ";
+    for (di = 0; di < 3; di++) cout << photon.dir_cosines[di] << " ";
     cout << endl;
     cout << "pos idx = ";
-    for (di = 0; di < 3; di++)
-      cout << photon.position_index[k][di] << " ";
+    for (di = 0; di < 3; di++) cout << photon.position_index[k][di] << " ";
     cout << endl;
-    cout << "k = " << k << " < " << photon.num_current_grids-1 << endl;
+    cout << "k = " << k << " < " << photon.num_current_grids - 1 << endl;
     cout << "dust_tau_per_pc = " << dust_tau_per_pc << endl;
     cout << "number of grids = " << geometry.grids.size() << endl;
     cout << "photon.current_grid_num = " << photon.current_grid_num << endl;
-    cout << "photon.grid_number[photon.current_grid_num] = " << photon.grid_number[photon.current_grid_num] << endl;
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+    cout << "photon.grid_number[photon.current_grid_num] = "
+         << photon.grid_number[photon.current_grid_num] << endl;
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nRow()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nCol()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.n3rd()
+         << endl;
   }
 #endif
 
-  if ((k < (photon.num_current_grids-1)) || (dust_tau_ref_per_pc <= -1.0)) {
+  if ((k < (photon.num_current_grids - 1)) || (dust_tau_ref_per_pc <= -1.0)) {
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
       cout << endl << "=============" << endl;
-      cout << "k, num_current_grids, dust_tau_per_pc, dust_tau_ref_per_pc = " << k << " " << photon.num_current_grids;
+      cout << "k, num_current_grids, dust_tau_per_pc, dust_tau_ref_per_pc = "
+           << k << " " << photon.num_current_grids;
       cout << " " << dust_tau_per_pc << " " << dust_tau_ref_per_pc << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
     }
 #endif
     photon.current_grid_num++;
-    // determine the position indexes for this subgrid (any more nested subgrids)
+    // determine the position indexes for this subgrid (any more nested
+    // subgrids)
     if (dust_tau_ref_per_pc <= -1.0) {
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-        cout << "new "; cout.flush();
+        cout << "new ";
+        cout.flush();
       }
+#endif
 
       // add in handling of subgrids
       // check if photon has already been in this grid
       // basically, are we restarting the photon tracking in a subgrid?
-
-#endif
       photon.grid_number[photon.current_grid_num] = -int(dust_tau_ref_per_pc);
 
       // check that the grid number is an actual integer
       // can have problems if tau is accidently set negative
-      if ((photon.grid_number[photon.current_grid_num] + dust_tau_ref_per_pc) != 0.0) {
+      if ((photon.grid_number[photon.current_grid_num] + dust_tau_ref_per_pc) !=
+          0.0) {
         cout << "problem with subgrid designation of in parent grid." << endl;
         cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
-        cout << "photon.grid_number[photon.current_grid_num] = " << photon.grid_number[photon.current_grid_num] << endl;
+        cout << "photon.grid_number[photon.current_grid_num] = "
+             << photon.grid_number[photon.current_grid_num] << endl;
         exit(8);
       }
 
-      if (photon.grid_number[photon.current_grid_num] >= int(geometry.grids.size())) {
+      if (photon.grid_number[photon.current_grid_num] >=
+          int(geometry.grids.size())) {
         cout << "grid desired does not exist" << endl;
-        cout << "grid desired = " << photon.grid_number[photon.current_grid_num] << endl;
+        cout << "grid desired = " << photon.grid_number[photon.current_grid_num]
+             << endl;
         cout << "# of grids = " << geometry.grids.size() << endl;
         cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
         exit(8);
@@ -134,27 +163,40 @@ double calc_delta_dist (photon_data& photon,
       cout << "subgrid found" << endl;
       cout << "target_tau = " << target_tau << endl;
       cout << "tau_traveled = " << tau_traveled << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
     }
 #endif
 
-    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled);
+    distance_traveled = calc_photon_trajectory(
+        photon, geometry, target_tau, target_dist, escape, tau_traveled, 0);
 
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
       cout << "emerging from subgrid" << endl;
       cout << "target_tau = " << target_tau << endl;
       cout << "tau_traveled = " << tau_traveled << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
     }
 #endif
 
     int escape_grid = 0;
-    if (escape) { // determine which of x,y,z exited first
+    if (escape) {  // determine which of x,y,z exited first
       photon.current_grid_num--;
       photon.num_current_grids--;
       int i = 0;
@@ -163,16 +205,24 @@ double calc_delta_dist (photon_data& photon,
       exit_cell = 1;
       for (i = 0; i < 3; i++) {
         if (((photon.dir_cosines[i] > 0.0) &&
-            (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1])) ||
+             (photon.position[i] ==
+              geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .positions[i][photon.position_index[k][i] + 1])) ||
             ((photon.dir_cosines[i] < 0.0) &&
-            (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]])))
+             (photon.position[i] ==
+              geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .positions[i][photon.position_index[k][i]])))
           min_index = i;
 #ifdef DEBUG_CDD
         if (photon.number == OUTNUM) {
           cout << "position, cell wall+/- = ";
           cout << photon.position[i] << " ";
-          cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]] << " ";
-          cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << endl;
+          cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                      .positions[i][photon.position_index[k][i]]
+               << " ";
+          cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                      .positions[i][photon.position_index[k][i] + 1]
+               << endl;
         }
 #endif
       }
@@ -195,20 +245,28 @@ double calc_delta_dist (photon_data& photon,
       cout << photon.current_grid_num << " ";
       cout << photon.num_current_grids << endl;
       cout << "min_index = " << min_index << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
       cout << "=============" << endl;
     }
 #endif
 
-  } else { // otherwise determine the distance in this cell
+  } else {  // otherwise determine the distance in this cell
 
-    double delta_position[3];  // x,y,z distance to the edge of the cell (parallel to the x,y,z axes)
-    double delta_distance[3];  // distance the photon would need to travelel to exit the cell in the x,y,z directions
+    double delta_position[3];  // x,y,z distance to the edge of the cell
+                               // (parallel to the x,y,z axes)
+    double delta_distance[3];  // distance the photon would need to travelel to
+                               // exit the cell in the x,y,z directions
 
-  // determine the x,y,z distances to the edge of the cell
-  //   this is parallel to the x,y,z axes
+    // determine the x,y,z distances to the edge of the cell
+    //   this is parallel to the x,y,z axes
     int i = 0;
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
@@ -217,19 +275,23 @@ double calc_delta_dist (photon_data& photon,
 #endif
     for (i = 0; i < 3; i++) {
       if (photon.dir_cosines[i] > 0.0) {
-        delta_position[i] = geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] -
-          photon.position[i];
-            } else if (photon.dir_cosines[i] < 0.0) {
-        delta_position[i] = photon.position[i] -
-          geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]];
-            } else {  // photon.dir_cosines[i] == 0.0
+        delta_position[i] =
+            geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .positions[i][photon.position_index[k][i] + 1] -
+            photon.position[i];
+      } else if (photon.dir_cosines[i] < 0.0) {
+        delta_position[i] =
+            photon.position[i] -
+            geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .positions[i][photon.position_index[k][i]];
+      } else {  // photon.dir_cosines[i] == 0.0
         delta_position[i] = 0.0;
       }
 
-      // calculate the distance the photon would  have to travel in each x,y,z direction
-      // to exit the cell
+      // calculate the distance the photon would  have to travel in each x,y,z
+      // direction to exit the cell
       if (photon.dir_cosines[i] != 0.0)
-        delta_distance[i] = fabs(delta_position[i]/photon.dir_cosines[i]);
+        delta_distance[i] = fabs(delta_position[i] / photon.dir_cosines[i]);
       else
         delta_distance[i] = 0.0;
 #ifdef DEBUG_CDD
@@ -239,12 +301,20 @@ double calc_delta_dist (photon_data& photon,
         cout << delta_position[i] << " ";
         cout << delta_distance[i] << " ";
         cout << photon.dir_cosines[i] << " ";
-        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                    .positions[i][photon.position_index[k][i] + 1]
+             << " ";
         cout << photon.position[i] << " ";
         cout << endl;
-        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                    .grid.nRow()
+             << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                    .grid.nCol()
+             << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                    .grid.n3rd()
+             << endl;
       }
 #endif
     }
@@ -263,20 +333,25 @@ double calc_delta_dist (photon_data& photon,
     if (min_index == -1) {
       // find the first non-zero dir cosine to send the photon along
       min_index = 0;
-      while (photon.dir_cosines[min_index] == 0.0)
-         min_index++;
+      while (photon.dir_cosines[min_index] == 0.0) min_index++;
       if ((min_index == 2) && (photon.dir_cosines[min_index] == 0.0)) {
-         cout << "no nonzero distances traveled in this cell." << endl;
-         exit(8);
+        cout << "no nonzero distances traveled in this cell." << endl;
+        exit(8);
       }
     }
 
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
       cout << "index transversed = " << min_index << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
     }
 #endif
     // save the current cell dust coeff (tau/pc)
@@ -284,16 +359,17 @@ double calc_delta_dist (photon_data& photon,
     distance_traveled = delta_distance[min_index];
 
     // determine the optical depth transversed before the photon exits the cell
-    tau_traveled = dust_tau_per_pc*distance_traveled;
+    tau_traveled = dust_tau_per_pc * distance_traveled;
 
-    // if this tau_traveled is larger than the amount of tau_left, then decrease the distance/tau traveled
-    // 2nd if statement is the same for distance
+    // if this tau_traveled is larger than the amount of tau_left, then decrease
+    // the distance/tau traveled 2nd if statement is the same for distance
     if (tau_traveled > target_tau) {
-      distance_traveled *= target_tau/tau_traveled;
+      distance_traveled *= target_tau / tau_traveled;
       tau_traveled = target_tau;
       exit_cell = 0;
-    } if (distance_traveled > target_dist) {
-      tau_traveled *= target_dist/distance_traveled;
+    }
+    if (distance_traveled > target_dist) {
+      tau_traveled *= target_dist / distance_traveled;
       distance_traveled = target_dist;
       exit_cell = 0;
     }
@@ -314,13 +390,19 @@ double calc_delta_dist (photon_data& photon,
       cout << "path info" << endl;
       cout << photon.path_cur_cells << endl;
       cout << photon.path_max_cells << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
     }
 #endif
 
-    if (photon.path_cur_cells >= 0) { // if -1, don't save
+    if (photon.path_cur_cells >= 0) {  // if -1, don't save
       if (photon.path_cur_cells >= photon.path_max_cells) {
         // lengthen the photon.path variables
         photon.path_tau.push_back(0.0);
@@ -331,14 +413,18 @@ double calc_delta_dist (photon_data& photon,
         photon.path_max_cells++;
       }
       if (photon.path_max_cells < photon.path_cur_cells) {
-        cout << "photon path # cells is smaller than the current cell number" << endl;
+        cout << "photon path # cells is smaller than the current cell number"
+             << endl;
         exit(8);
       }
       photon.path_tau[photon.path_cur_cells] = tau_traveled;
       photon.path_pos_index[0][photon.path_cur_cells] = grid_val;
-      photon.path_pos_index[1][photon.path_cur_cells] = photon.position_index[k][0];
-      photon.path_pos_index[2][photon.path_cur_cells] = photon.position_index[k][1];
-      photon.path_pos_index[3][photon.path_cur_cells] = photon.position_index[k][2];
+      photon.path_pos_index[1][photon.path_cur_cells] =
+          photon.position_index[k][0];
+      photon.path_pos_index[2][photon.path_cur_cells] =
+          photon.position_index[k][1];
+      photon.path_pos_index[3][photon.path_cur_cells] =
+          photon.position_index[k][2];
 
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
@@ -368,21 +454,29 @@ double calc_delta_dist (photon_data& photon,
       cout << photon.current_grid_num << " ";
       cout << photon.num_current_grids << endl;
       cout << "min_index = " << min_index << endl;
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
       cout << "-----" << endl;
     }
 #endif
-  // update the photon position for the distance_traveled
+    // update the photon position for the distance_traveled
     for (i = 0; i < 3; i++) {
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-        cout << "pos, delta_pos = " << photon.position[i] << " " << distance_traveled*photon.dir_cosines[i];
-        cout << " " << distance_traveled << " " << photon.dir_cosines[i] << endl;
+        cout << "pos, delta_pos = " << photon.position[i] << " "
+             << distance_traveled * photon.dir_cosines[i];
+        cout << " " << distance_traveled << " " << photon.dir_cosines[i]
+             << endl;
       }
 #endif
-      photon.position[i] += distance_traveled*photon.dir_cosines[i];
+      photon.position[i] += distance_traveled * photon.dir_cosines[i];
     }
   }
 
@@ -394,9 +488,13 @@ double calc_delta_dist (photon_data& photon,
   if (exit_cell) {
     if (photon.dir_cosines[min_index] > 0.0) {
       photon.position_index[k][min_index]++;
-      photon.position[min_index] = geometry.grids[photon.grid_number[photon.current_grid_num]].positions[min_index][photon.position_index[k][min_index]];
+      photon.position[min_index] =
+          geometry.grids[photon.grid_number[photon.current_grid_num]]
+              .positions[min_index][photon.position_index[k][min_index]];
     } else {
-      photon.position[min_index] = geometry.grids[photon.grid_number[photon.current_grid_num]].positions[min_index][photon.position_index[k][min_index]];
+      photon.position[min_index] =
+          geometry.grids[photon.grid_number[photon.current_grid_num]]
+              .positions[min_index][photon.position_index[k][min_index]];
       photon.position_index[k][min_index]--;
     }
 
@@ -407,37 +505,52 @@ double calc_delta_dist (photon_data& photon,
     }
 #endif
     if (!escape)
-      if ((photon.position_index[k][min_index] >= geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index]) ||
+      if ((photon.position_index[k][min_index] >=
+           geometry.grids[photon.grid_number[photon.current_grid_num]]
+               .index_dim[min_index]) ||
           (photon.position_index[k][min_index] < 0))
         escape = 1;
-
+        
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
       cout << photon.position_index[k][min_index] << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index] << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-      cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .index_dim[min_index]
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nRow()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.nCol()
+           << " ";
+      cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                  .grid.n3rd()
+           << endl;
       cout << "escape (post check1) = " << escape << endl;
     }
 #endif
 
-    // determine if the photon has left the model while still inside the grid (-1 > dust_tau_per_pc > 0)
+    // determine if the photon has left the model while still inside the grid
+    // (-1 > dust_tau_per_pc > 0)
     if (!escape) {
-//       if ((photon.position_index[k][min_index] < geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index]) &&
-// 	  (photon.position_index[k][min_index] >= 0)) {
-      dust_tau_ref_per_pc = geometry.grids[photon.grid_number[photon.current_grid_num]].
-        grid(photon.position_index[k][0],photon.position_index[k][1],photon.position_index[k][2]).dust_tau_per_pc;
+      //       if ((photon.position_index[k][min_index] <
+      //       geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index])
+      //       &&
+      // 	  (photon.position_index[k][min_index] >= 0)) {
+      dust_tau_ref_per_pc =
+          geometry.grids[photon.grid_number[photon.current_grid_num]]
+              .grid(photon.position_index[k][0], photon.position_index[k][1],
+                    photon.position_index[k][2])
+              .dust_tau_per_pc;
       if ((dust_tau_ref_per_pc > -1.0) && (dust_tau_ref_per_pc < 0.0))
         escape = 1;
-//       }
+      //       }
     }
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
       cout << "escape (post check2) = " << escape << endl;
     }
 #endif
-
   }
 
 #ifdef DEBUG_CDD
@@ -447,21 +560,25 @@ double calc_delta_dist (photon_data& photon,
     cout << tau_traveled << endl;
     cout << "tau target = " << target_tau << endl;
     cout << "pos = ";
-    for (di = 0; di < 3; di++)
-      cout << photon.position[di] << " ";
+    for (di = 0; di < 3; di++) cout << photon.position[di] << " ";
     cout << endl;
     cout << "pos idx = ";
-    for (di = 0; di < 3; di++)
-      cout << photon.position_index[k][di] << " ";
+    for (di = 0; di < 3; di++) cout << photon.position_index[k][di] << " ";
     cout << endl;
     cout << "exit_cell = " << exit_cell << endl;
     cout << "escape = " << escape << endl;
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-    cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nRow()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.nCol()
+         << " ";
+    cout << geometry.grids[photon.grid_number[photon.current_grid_num]]
+                .grid.n3rd()
+         << endl;
     cout << "photon.path_cur_cells = " << photon.path_cur_cells << endl;
   }
 #endif
 
-  return(distance_traveled);
+  return (distance_traveled);
 }

--- a/DIRTY/calc_delta_dist.cpp
+++ b/DIRTY/calc_delta_dist.cpp
@@ -100,7 +100,7 @@ double calc_delta_dist (photon_data& photon,
     if (dust_tau_ref_per_pc <= -1.0) {
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-	cout << "new "; cout.flush();
+        cout << "new "; cout.flush();
       }
 
       // add in handling of subgrids
@@ -113,18 +113,18 @@ double calc_delta_dist (photon_data& photon,
       // check that the grid number is an actual integer
       // can have problems if tau is accidently set negative
       if ((photon.grid_number[photon.current_grid_num] + dust_tau_ref_per_pc) != 0.0) {
-	cout << "problem with subgrid designation of in parent grid." << endl;
-	cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
-	cout << "photon.grid_number[photon.current_grid_num] = " << photon.grid_number[photon.current_grid_num] << endl;
-	exit(8);
+        cout << "problem with subgrid designation of in parent grid." << endl;
+        cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
+        cout << "photon.grid_number[photon.current_grid_num] = " << photon.grid_number[photon.current_grid_num] << endl;
+        exit(8);
       }
 
       if (photon.grid_number[photon.current_grid_num] >= int(geometry.grids.size())) {
-	cout << "grid desired does not exist" << endl;
-	cout << "grid desired = " << photon.grid_number[photon.current_grid_num] << endl;
-	cout << "# of grids = " << geometry.grids.size() << endl;
-	cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
-	exit(8);
+        cout << "grid desired does not exist" << endl;
+        cout << "grid desired = " << photon.grid_number[photon.current_grid_num] << endl;
+        cout << "# of grids = " << geometry.grids.size() << endl;
+        cout << "dust_tau_ref_per_pc = " << dust_tau_ref_per_pc << endl;
+        exit(8);
       }
 
       determine_photon_position_index(geometry, photon);
@@ -162,18 +162,18 @@ double calc_delta_dist (photon_data& photon,
       escape_grid = 1;
       exit_cell = 1;
       for (i = 0; i < 3; i++) {
-	if (((photon.dir_cosines[i] > 0.0) &&
-	     (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1])) ||
-	    ((photon.dir_cosines[i] < 0.0) &&
-	     (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]])))
-	  min_index = i;
+        if (((photon.dir_cosines[i] > 0.0) &&
+            (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1])) ||
+            ((photon.dir_cosines[i] < 0.0) &&
+            (photon.position[i] == geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]])))
+          min_index = i;
 #ifdef DEBUG_CDD
-	if (photon.number == OUTNUM) {
-	  cout << "position, cell wall+/- = ";
-	  cout << photon.position[i] << " ";
-	  cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]] << " ";
-	  cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << endl;
-	}
+        if (photon.number == OUTNUM) {
+          cout << "position, cell wall+/- = ";
+          cout << photon.position[i] << " ";
+          cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]] << " ";
+          cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << endl;
+        }
 #endif
       }
     }
@@ -217,13 +217,13 @@ double calc_delta_dist (photon_data& photon,
 #endif
     for (i = 0; i < 3; i++) {
       if (photon.dir_cosines[i] > 0.0) {
-	delta_position[i] = geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] -
-	  photon.position[i];
-      } else if (photon.dir_cosines[i] < 0.0) {
-	delta_position[i] = photon.position[i] -
-	  geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]];
-      } else {  // photon.dir_cosines[i] == 0.0
-	delta_position[i] = 0.0;
+        delta_position[i] = geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] -
+          photon.position[i];
+            } else if (photon.dir_cosines[i] < 0.0) {
+        delta_position[i] = photon.position[i] -
+          geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]];
+            } else {  // photon.dir_cosines[i] == 0.0
+        delta_position[i] = 0.0;
       }
 
       // calculate the distance the photon would  have to travel in each x,y,z direction
@@ -234,17 +234,17 @@ double calc_delta_dist (photon_data& photon,
         delta_distance[i] = 0.0;
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-	cout << "i = " << i << " ";
-	cout << "delt pos dir = ";
-	cout << delta_position[i] << " ";
-	cout << delta_distance[i] << " ";
-	cout << photon.dir_cosines[i] << " ";
-	cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << " ";
-	cout << photon.position[i] << " ";
-	cout << endl;
-	cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
-	cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
-	cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
+        cout << "i = " << i << " ";
+        cout << "delt pos dir = ";
+        cout << delta_position[i] << " ";
+        cout << delta_distance[i] << " ";
+        cout << photon.dir_cosines[i] << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].positions[i][photon.position_index[k][i]+1] << " ";
+        cout << photon.position[i] << " ";
+        cout << endl;
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nRow() << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.nCol() << " ";
+        cout << geometry.grids[photon.grid_number[photon.current_grid_num]].grid.n3rd() << endl;
       }
 #endif
     }
@@ -255,9 +255,9 @@ double calc_delta_dist (photon_data& photon,
     min_index = -1;
     for (i = 0; i < 3; i++)
       if ((delta_distance[i] < min_dist) && (delta_distance[i] >= 0.) &&
-	  (!((photon.dir_cosines[i] == 0.0) && (delta_distance[i] == 0.0)))) {
-	min_dist = delta_distance[i];
-	min_index = i;
+          (!((photon.dir_cosines[i] == 0.0) && (delta_distance[i] == 0.0)))) {
+        min_dist = delta_distance[i];
+        min_index = i;
       }
 
     if (min_index == -1) {
@@ -322,17 +322,17 @@ double calc_delta_dist (photon_data& photon,
 
     if (photon.path_cur_cells >= 0) { // if -1, don't save
       if (photon.path_cur_cells >= photon.path_max_cells) {
-	// lengthen the photon.path variables
-	photon.path_tau.push_back(0.0);
-	photon.path_pos_index[0].push_back(0);
-	photon.path_pos_index[1].push_back(0);
-	photon.path_pos_index[2].push_back(0);
-	photon.path_pos_index[3].push_back(0);
-	photon.path_max_cells++;
+        // lengthen the photon.path variables
+        photon.path_tau.push_back(0.0);
+        photon.path_pos_index[0].push_back(0);
+        photon.path_pos_index[1].push_back(0);
+        photon.path_pos_index[2].push_back(0);
+        photon.path_pos_index[3].push_back(0);
+        photon.path_max_cells++;
       }
       if (photon.path_max_cells < photon.path_cur_cells) {
-	cout << "photon path # cells is smaller than the current cell number" << endl;
-	exit(8);
+        cout << "photon path # cells is smaller than the current cell number" << endl;
+        exit(8);
       }
       photon.path_tau[photon.path_cur_cells] = tau_traveled;
       photon.path_pos_index[0][photon.path_cur_cells] = grid_val;
@@ -342,19 +342,19 @@ double calc_delta_dist (photon_data& photon,
 
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-	cout << "path: ";
-	cout << photon.path_pos_index[0][photon.path_cur_cells] << " ";
-	cout << photon.path_pos_index[1][photon.path_cur_cells] << " ";
-	cout << photon.path_pos_index[2][photon.path_cur_cells] << " ";
-	cout << photon.path_pos_index[3][photon.path_cur_cells] << " ";
-	cout << photon.path_tau[photon.path_cur_cells] << endl;
+        cout << "path: ";
+        cout << photon.path_pos_index[0][photon.path_cur_cells] << " ";
+        cout << photon.path_pos_index[1][photon.path_cur_cells] << " ";
+        cout << photon.path_pos_index[2][photon.path_cur_cells] << " ";
+        cout << photon.path_pos_index[3][photon.path_cur_cells] << " ";
+        cout << photon.path_tau[photon.path_cur_cells] << endl;
       }
 #endif
       photon.path_cur_cells++;
 
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM)
-	cout << "photon.path_cur_cells = " << photon.path_cur_cells << endl;
+        cout << "photon.path_cur_cells = " << photon.path_cur_cells << endl;
 #endif
     }
 
@@ -378,8 +378,8 @@ double calc_delta_dist (photon_data& photon,
     for (i = 0; i < 3; i++) {
 #ifdef DEBUG_CDD
       if (photon.number == OUTNUM) {
-	cout << "pos, delta_pos = " << photon.position[i] << " " << distance_traveled*photon.dir_cosines[i];
-	cout << " " << distance_traveled << " " << photon.dir_cosines[i] << endl;
+        cout << "pos, delta_pos = " << photon.position[i] << " " << distance_traveled*photon.dir_cosines[i];
+        cout << " " << distance_traveled << " " << photon.dir_cosines[i] << endl;
       }
 #endif
       photon.position[i] += distance_traveled*photon.dir_cosines[i];
@@ -408,8 +408,8 @@ double calc_delta_dist (photon_data& photon,
 #endif
     if (!escape)
       if ((photon.position_index[k][min_index] >= geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index]) ||
-	  (photon.position_index[k][min_index] < 0))
-	escape = 1;
+          (photon.position_index[k][min_index] < 0))
+        escape = 1;
 
 #ifdef DEBUG_CDD
     if (photon.number == OUTNUM) {
@@ -426,10 +426,10 @@ double calc_delta_dist (photon_data& photon,
     if (!escape) {
 //       if ((photon.position_index[k][min_index] < geometry.grids[photon.grid_number[photon.current_grid_num]].index_dim[min_index]) &&
 // 	  (photon.position_index[k][min_index] >= 0)) {
-	dust_tau_ref_per_pc = geometry.grids[photon.grid_number[photon.current_grid_num]].
-	  grid(photon.position_index[k][0],photon.position_index[k][1],photon.position_index[k][2]).dust_tau_per_pc;
-	if ((dust_tau_ref_per_pc > -1.0) && (dust_tau_ref_per_pc < 0.0))
-	  escape = 1;
+      dust_tau_ref_per_pc = geometry.grids[photon.grid_number[photon.current_grid_num]].
+        grid(photon.position_index[k][0],photon.position_index[k][1],photon.position_index[k][2]).dust_tau_per_pc;
+      if ((dust_tau_ref_per_pc > -1.0) && (dust_tau_ref_per_pc < 0.0))
+        escape = 1;
 //       }
     }
 #ifdef DEBUG_CDD

--- a/DIRTY/calc_photon_trajectory.cpp
+++ b/DIRTY/calc_photon_trajectory.cpp
@@ -10,19 +10,17 @@
 // 2003 Jun/KDG - written
 // ======================================================================
 #include "calc_photon_trajectory.h"
-//#define PHOTON_POS
-//#define OUTNUM 0
-//#define DEBUG_CPT
+// #define PHOTON_POS
+// #define OUTNUM 0
+// #define DEBUG_CPT
 
-double calc_photon_trajectory (photon_data& photon,
-			       geometry_struct& geometry,
-			       double target_tau,
-			       double target_dist,
-			       int& escape,
-			       double& tau_traveled)
+double calc_photon_trajectory(photon_data& photon, geometry_struct& geometry,
+                              double target_tau, double target_dist,
+                              int& escape, double& tau_traveled,
+                              int repeat_boundary)
 
 {
-  double tau_left = target_tau;  // reduce till zero = done
+  double tau_left = target_tau;    // reduce till zero = done
   double dist_left = target_dist;  // reduce till zero = done
 #ifdef DEBUG_CPT
   if (photon.number == OUTNUM) {
@@ -37,10 +35,10 @@ double calc_photon_trajectory (photon_data& photon,
   double delta_dist = 0.0;
 
   // move through the grid until escaping or reaching the target tau
-  //   need to also handle the case where the photon starts several subgrids down
-  //   multiple calls to calc_photon_trajectory needed
-  while ((tau_left > ROUNDOFF_ERR_TRIG) && (dist_left > ROUNDOFF_ERR_TRIG) && (!escape)) {
-
+  //   need to also handle the case where the photon starts several subgrids
+  //   down multiple calls to calc_photon_trajectory needed
+  while ((tau_left > ROUNDOFF_ERR_TRIG) && (dist_left > ROUNDOFF_ERR_TRIG) &&
+         (!escape)) {
 #ifdef DEBUG_CPT
     if (photon.number == OUTNUM) {
       cout << "before delta distance & tau_left & delta_tau & escape = ";
@@ -53,11 +51,11 @@ double calc_photon_trajectory (photon_data& photon,
       cout << photon.num_current_grids << endl;
     }
 #endif
-    delta_dist = calc_delta_dist(photon, geometry, tau_left, dist_left, escape, delta_tau);
+    delta_dist = calc_delta_dist(photon, geometry, tau_left, dist_left, escape,
+                                 delta_tau);
 #ifdef PHOTON_POS
     int i = 0;
-    for (i = 0; i < 3; i++)
-      cout << photon.position[i] << " ";
+    for (i = 0; i < 3; i++) cout << photon.position[i] << " ";
     cout << endl;
 #endif
     tau_traveled += delta_tau;
@@ -77,41 +75,103 @@ double calc_photon_trajectory (photon_data& photon,
       cout << photon.num_current_grids << endl;
     }
 #endif
+
+    // if the photon has escaped the main grid and if repeat boundary option is
+    // set, then move the photon to the opposite side of the main grid
+    if ((repeat_boundary) && (geometry.repeat_boundary_xy) && (escape) &&
+        (photon.current_grid_num == 0)) {
+      int i;
+      // cout << photon.number << " " << tau_left << " " << dist_left << endl;
+      // cout << "escaped main grid." << endl;
+      // for (i = 0; i < 3; i++) cout << photon.position[i] << " ";ls
+
+      // cout << endl;
+      // for (i = 0; i < 3; i++) cout << photon.position_index[0][i] << " ";
+      // cout << endl;
+
+      // for (i = 0; i < 3; i++)
+      //   cout << i << " " << geometry.grids[0].positions[i][0] << " "
+      //        <<
+      //        geometry.grids[0].positions[i][geometry.grids[0].index_dim[i]]
+      //        << endl;
+      // cout << endl;
+
+      // only check x and y, do not repeat z boundary
+      int found_repeat = 0;
+      for (i = 0; i < 2; i++) {
+        if (photon.position[i] == geometry.grids[0].positions[i][0]) {
+          photon.position[i] *= -1.0;
+          found_repeat = 1;
+        } else if (photon.position[i] ==
+                   geometry.grids[0]
+                       .positions[i][geometry.grids[0].index_dim[i]]) {
+          photon.position[i] *= -1.0;
+          found_repeat = 1;
+        }
+      }
+
+      if (found_repeat) {
+        determine_photon_position_index(geometry, photon);
+        escape = 0;
+
+        // cout << photon.number << " " << tau_left << " " << dist_left << endl;
+        // cout << "new positions" << endl;
+        // for (i = 0; i < 3; i++) cout << photon.position[i] << " ";
+        // cout << endl;
+        // for (i = 0; i < 3; i++) cout << photon.position_index[0][i] << " ";
+        // cout << endl;
+      }
+    }
   }
 
   // check if the photon is in the right grid cell
   // this should be a temporary check...
   // make sure the photon is in this grid
-//   int k = photon.current_grid_num;
-//   int cur_grid_num = photon.grid_number[k];
-//   int i = 0;
-//   for (i = 0; i < 3; i++) {
-//     if ((photon.position[i] < geometry.grids[cur_grid_num].positions[i][0]) ||
-// 	(photon.position[i] > geometry.grids[cur_grid_num].positions[i][geometry.grids[cur_grid_num].index_dim[i]])) {
-//       cout << "outside of bounds of current grid (in calc_photon_trajectory.cpp)" << endl;
-//       cout << "This should not happen." << endl;
-//       cout << "photon # = " << photon.number << endl;
-//       cout << "i = " << i << endl;
-//       cout << "photon.position[i] = " << photon.position[i] << endl;
-//       cout << "photon.birth_position[i] = " << photon.birth_position[i] << endl;
-//       cout << "photon.dir_consines[i] = " << photon.dir_cosines[i] << endl;
-//       cout << "photon.num_scat = " << photon.num_scat << endl;
-//       cout << "cur_grid_num = " << cur_grid_num << endl;
-//       cout << "min/max of grid = " << geometry.grids[cur_grid_num].positions[i][0] << " ";
-//       cout << geometry.grids[cur_grid_num].positions[i][geometry.grids[cur_grid_num].index_dim[i]] << endl;
-//       cout << "size of cube [pc] = " << geometry.grids[cur_grid_num].phys_cube_size[i] << endl;
-//       cout << "proposed index = " << int((photon.position[i] - geometry.grids[cur_grid_num].positions[i][0])/
-// 					 geometry.grids[cur_grid_num].phys_cube_size[i]) << endl;
-//       cout << "real value of pindex = " << (photon.position[i] - geometry.grids[cur_grid_num].positions[i][0])/
-// 	geometry.grids[cur_grid_num].phys_cube_size[i] << endl;
-//       cout << "out of a possible " << geometry.grids[cur_grid_num].index_dim[i] << endl;
-//       cout << "out of a possible2 " << geometry.grids[cur_grid_num].positions[i].size() << endl;
-//       int parent_grid_num = geometry.grids[cur_grid_num].parent_grid_num;
-//       cout << "parent grid cell min = " << geometry.grids[parent_grid_num].positions[i][photon.position_index[k-1][i]] << endl;
-//       cout << "parent grid cell max = " << geometry.grids[parent_grid_num].positions[i][photon.position_index[k-1][i]+1] << endl;
-//       exit(8);
-//     }
-//   }
+  //   int k = photon.current_grid_num;
+  //   int cur_grid_num = photon.grid_number[k];
+  //   int i = 0;
+  //   for (i = 0; i < 3; i++) {
+  //     if ((photon.position[i] <
+  //     geometry.grids[cur_grid_num].positions[i][0])
+  //     ||
+  // 	(photon.position[i] >
+  // geometry.grids[cur_grid_num].positions[i][geometry.grids[cur_grid_num].index_dim[i]]))
+  // {
+  //       cout << "outside of bounds of current grid (in
+  //       calc_photon_trajectory.cpp)" << endl; cout << "This should not
+  //       happen." << endl; cout << "photon # = " << photon.number << endl;
+  //       cout << "i = " << i << endl;
+  //       cout << "photon.position[i] = " << photon.position[i] << endl;
+  //       cout << "photon.birth_position[i] = " << photon.birth_position[i]
+  //       << endl; cout << "photon.dir_consines[i] = " <<
+  //       photon.dir_cosines[i] << endl; cout << "photon.num_scat = " <<
+  //       photon.num_scat << endl; cout
+  //       << "cur_grid_num = " << cur_grid_num << endl; cout << "min/max of
+  //       grid = " << geometry.grids[cur_grid_num].positions[i][0] << " ";
+  //       cout
+  //       <<
+  //       geometry.grids[cur_grid_num].positions[i][geometry.grids[cur_grid_num].index_dim[i]]
+  //       << endl; cout << "size of cube [pc] = " <<
+  //       geometry.grids[cur_grid_num].phys_cube_size[i] << endl; cout <<
+  //       "proposed index = " << int((photon.position[i] -
+  //       geometry.grids[cur_grid_num].positions[i][0])/
+  // 					 geometry.grids[cur_grid_num].phys_cube_size[i])
+  // << endl;
+  //       cout << "real value of pindex = " << (photon.position[i] -
+  //       geometry.grids[cur_grid_num].positions[i][0])/
+  // 	geometry.grids[cur_grid_num].phys_cube_size[i] << endl;
+  //       cout << "out of a possible " <<
+  //       geometry.grids[cur_grid_num].index_dim[i] << endl; cout << "out of
+  //       a possible2 " << geometry.grids[cur_grid_num].positions[i].size()
+  //       << endl; int parent_grid_num =
+  //       geometry.grids[cur_grid_num].parent_grid_num; cout << "parent grid
+  //       cell min = " <<
+  //       geometry.grids[parent_grid_num].positions[i][photon.position_index[k-1][i]]
+  //       << endl; cout << "parent grid cell max = " <<
+  //       geometry.grids[parent_grid_num].positions[i][photon.position_index[k-1][i]+1]
+  //       << endl; exit(8);
+  //     }
+  //   }
 
-  return(distance_traveled);
+  return (distance_traveled);
 }

--- a/DIRTY/forced_first_scatter.cpp
+++ b/DIRTY/forced_first_scatter.cpp
@@ -43,7 +43,7 @@ int forced_first_scatter (geometry_struct& geometry,
   //dummy_photon.path_cur_cells = -1;  // set to -1 *not* to save cells tranversed
   dummy_photon.path_cur_cells = 0;  // set to 0 to save cells transversed
 
-  distance_traveled = calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, ffs_escape, tau_to_surface);
+  distance_traveled = calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, ffs_escape, tau_to_surface, 0);
   photon.first_tau = tau_to_surface;
   photon.prev_tau_surface = tau_to_surface;
 
@@ -134,7 +134,7 @@ int forced_first_scatter (geometry_struct& geometry,
 #ifdef DEBUG_FFS
     if (photon.number == OUTNUM) cout << "tau_traveled in = " << tau_traveled << endl;
 #endif
-    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled);
+    distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled, 0);
 
     // cout << photon.number << " ";
     // cout << target_tau << " ";

--- a/DIRTY/get_run_parameters.cpp
+++ b/DIRTY/get_run_parameters.cpp
@@ -53,6 +53,14 @@ void get_run_parameters(ConfigFile& param_data, output_struct& output,
   check_input_param("emit_bias_fraction", geometry.emit_bias_fraction, 0.0,
                     1.0);
 
+  // repeat xy boundary - only works for models that fully fill the main grid with dust
+  geometry.repeat_boundary_xy =
+      param_data.IValue("Run", "repeat_boundary_xy");
+  if (geometry.repeat_boundary_xy == -99)
+    geometry.repeat_boundary_xy = 0;  // set to no if not initially set
+  check_input_param("repeat_boundary_xy",
+                    geometry.repeat_boundary_xy, 0, 1);
+
   int image_size = param_data.IValue("Run", "output_image_size");
   if (image_size > 0) {
     check_input_param("output_image_size", image_size, 1, 50000);
@@ -72,7 +80,8 @@ void get_run_parameters(ConfigFile& param_data, output_struct& output,
   }
 
   if ((image_size < 0) && (image_x_size < 0) && (image_y_size < 0)) {
-    cout << "either image_size or (image_x_size, image_y_size) need to be set." << endl;
+    cout << "either image_size or (image_x_size, image_y_size) need to be set."
+         << endl;
     exit(8);
   }
 

--- a/DIRTY/include/calc_delta_dist.h
+++ b/DIRTY/include/calc_delta_dist.h
@@ -1,23 +1,22 @@
 #ifndef _DIRTY_CALC_DELTA_DIST__
 #define _DIRTY_CALC_DELTA_DIST__
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
 #include "roundoff_err.h"
-#include "debug.h"
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 
-extern void determine_photon_position_index (geometry_struct& geometry,
-					     photon_data& photon);
+extern void determine_photon_position_index(geometry_struct& geometry,
+                                            photon_data& photon);
 
 #endif

--- a/DIRTY/include/calc_photon_trajectory.h
+++ b/DIRTY/include/calc_photon_trajectory.h
@@ -1,8 +1,8 @@
 #ifndef _DIRTY_CALC_PHOTON_TRAJECTORY_
 #define _DIRTY_CALC_PHOTON_TRAJECTORY_
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
 #include "debug.h"
 #include "geometry_def.h"
@@ -11,16 +11,15 @@
 
 // determines the vector of positions and grid numbers given the photon
 // position and direction
-extern void determine_grid_position_index (geometry_struct& geometry,
-					   photon_data& photon);
+extern void determine_grid_position_index(geometry_struct& geometry,
+                                          photon_data& photon);
 
 // function to calculate the distance traveled inside a cell
-extern double calc_delta_dist (photon_data& photon,
-			       geometry_struct& geometry,
-			       double target_tau,
-			       double target_dist,
-			       int& escape,
-			       double& tau_traveled);
+extern double calc_delta_dist(photon_data& photon, geometry_struct& geometry,
+                              double target_tau, double target_dist,
+                              int& escape, double& tau_traveled);
 
+extern void determine_photon_position_index(geometry_struct& geometry,
+                                            photon_data& photon);
 
 #endif

--- a/DIRTY/include/forced_first_scatter.h
+++ b/DIRTY/include/forced_first_scatter.h
@@ -1,27 +1,26 @@
 #ifndef _DIRTY_FORCED_FIRST_SCATTER_
 #define _DIRTY_FORCED_FIRST_SCATTER_
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
 #include "random_dirty.h"
 #include "roundoff_err.h"
-#include "debug.h"
 
 //**********************************************************************
 // external function definitions
 
-extern void determine_photon_position_index_initial (geometry_struct& geometry,
-  					             photon_data& photon);
+extern void determine_photon_position_index_initial(geometry_struct& geometry,
+                                                    photon_data& photon);
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 
 #endif

--- a/DIRTY/include/geometry_def.h
+++ b/DIRTY/include/geometry_def.h
@@ -128,6 +128,8 @@ struct geometry_struct {
   double scat_bias_fraction;
   double scat_angle_bias_fraction;
   double emit_bias_fraction;
+
+  int repeat_boundary_xy;
 };
 
 #endif

--- a/DIRTY/include/new_photon_diffuse_source.h
+++ b/DIRTY/include/new_photon_diffuse_source.h
@@ -1,29 +1,28 @@
 #ifndef _DIRTY_NEW_PHOTON_DIFFUSE_SOURCE_
 #define _DIRTY_NEW_PHOTON_DIFFUSE_SOURCE_
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
-#include "geometry_def.h"
-#include "random_dirty.h"
-#include "photon_data.h"
 #include "debug.h"
+#include "geometry_def.h"
+#include "photon_data.h"
+#include "random_dirty.h"
 
 // determines the vector of positions and grid numbers given the photon
 // position and direction
-extern void determine_photon_position_index_initial (geometry_struct& geometry,
-						     photon_data& photon);
+extern void determine_photon_position_index_initial(geometry_struct& geometry,
+                                                    photon_data& photon);
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 
 // just applies the rotation
-extern void rotate_zaxis_for_observer (float transform[3][3],
-				       photon_data& photon);
+extern void rotate_zaxis_for_observer(float transform[3][3],
+                                      photon_data& photon);
 
 #endif

--- a/DIRTY/include/next_scatter.h
+++ b/DIRTY/include/next_scatter.h
@@ -1,23 +1,22 @@
 #ifndef _DIRTY_NEXT_SCATTER_
 #define _DIRTY_NEXT_SCATTER_
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
 #include "random_dirty.h"
 #include "roundoff_err.h"
-#include "debug.h"
 
 //**********************************************************************
 // external function definitions
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 #endif

--- a/DIRTY/include/scatter_photon.h
+++ b/DIRTY/include/scatter_photon.h
@@ -1,24 +1,23 @@
 #ifndef _DIRTY_SCATTER_PHOTON_
 #define _DIRTY_SCATTER_PHOTON_
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
 #include "random_dirty.h"
 #include "roundoff_err.h"
-#include "debug.h"
 
 //**********************************************************************
 // external function definitions
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 
 #endif

--- a/DIRTY/include/scattered_weight_towards_observer.h
+++ b/DIRTY/include/scattered_weight_towards_observer.h
@@ -1,20 +1,19 @@
 #ifndef _DIRTY_SCATTERED_WEIGHT_TOWARDS_OBSERVER__
 #define _DIRTY_SCATTERED_WEIGHT_TOWARDS_OBSERVER__
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
-#include "debug.h"
 
 // determines the photon trajectory (returns the distance and tau traveled)
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 #endif

--- a/DIRTY/include/stellar_weight_towards_observer.h
+++ b/DIRTY/include/stellar_weight_towards_observer.h
@@ -1,23 +1,22 @@
 #ifndef _DIRTY_STELLAR_WEIGHT_TOWARDS_OBSERVER__
 #define _DIRTY_STELLAR_WEIGHT_TOWARDS_OBSERVER__
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
+#include "debug.h"
 #include "geometry_def.h"
 #include "photon_data.h"
-#include "debug.h"
 
 // determines the vector of positions and grid numbers given the photon
 // position and direction
-extern void determine_photon_position_index_initial (geometry_struct& geometry,
-						     photon_data& photon);
+extern void determine_photon_position_index_initial(geometry_struct& geometry,
+                                                    photon_data& photon);
 
 // determines the photon trajectory (returns the distance and tau traveled)
-extern double calc_photon_trajectory (photon_data& photon,
-				      geometry_struct& geometry,
-				      double target_tau,
-				      double target_dist,
-				      int& escape,
-				      double& tau_traveled);
+extern double calc_photon_trajectory(photon_data& photon,
+                                     geometry_struct& geometry,
+                                     double target_tau, double target_dist,
+                                     int& escape, double& tau_traveled,
+                                     int repeat_boundary);
 #endif

--- a/DIRTY/new_photon_diffuse_source.cpp
+++ b/DIRTY/new_photon_diffuse_source.cpp
@@ -126,7 +126,7 @@ void new_photon_diffuse_source (photon_data& photon,
   cout << "np; start distance traveled" << " ";
   cout.flush();
 #endif
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_to_surface);
+  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_to_surface, 0);
 #ifdef DEBUG_NPDS
   cout << "np; done distance traveled" << " ";
   cout.flush();

--- a/DIRTY/next_scatter.cpp
+++ b/DIRTY/next_scatter.cpp
@@ -17,14 +17,14 @@ int next_scatter (geometry_struct& geometry,
 {
   // find path_tau[]
   photon_data dummy_photon = photon;
-  dummy_photon.current_grid_num = 0;  // set to the base grid to start tarjectory correctly
+  dummy_photon.current_grid_num = 0;  // set to the base grid to start trajectory correctly
   dummy_photon.path_cur_cells = 0; // set to 0 to save cells traversed
 
   double target_tau = 1e20;
   double target_dist = 1e10*geometry.radius;
   int escape = 0;
   double tau_path = 0.0;
-  calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, escape, tau_path);
+  calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, escape, tau_path, 0);
   double bias_norm = 1.0/(1.0 + tau_path);
 //   cout << tau_path << " ";
 //   cout << bias_norm << " ";
@@ -58,7 +58,7 @@ int next_scatter (geometry_struct& geometry,
   escape = 0;
   photon.path_cur_cells = 0;  // set to 0 to save cells tranversed
 
-  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled);
+  distance_traveled = calc_photon_trajectory(photon, geometry, target_tau, target_dist, escape, tau_traveled, 1);
 #ifdef DEBUG_NS
   if (photon.number == OUTNUM) {
     cout << "ns cpt done; ";

--- a/DIRTY/scatter_photon.cpp
+++ b/DIRTY/scatter_photon.cpp
@@ -52,7 +52,7 @@ void scatter_photon (geometry_struct& geometry,
     double ran_num2 = random_obj.random_num();
     if (ran_num >= geometry.scat_angle_bias_fraction) { // sample from HG function
       cos_alpha = (1.0 + sqr_g) -
-	pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*ran_num2),2);
+        pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*ran_num2),2);
       cos_alpha /= (2.0*geometry.g);
     } else { // sample from isotropic function
       cos_alpha = 2.0*ran_num2 - 1.0;

--- a/DIRTY/scatter_photon.cpp
+++ b/DIRTY/scatter_photon.cpp
@@ -7,62 +7,68 @@
 // 2013 Oct/KDG - updated to work with subgrids
 // ======================================================================
 #include "scatter_photon.h"
-//#define DEBUG_SP
+// #define DEBUG_SP
 
-void scatter_photon (geometry_struct& geometry,
-		     photon_data& photon,
-		     random_dirty& random_obj)
+void scatter_photon(geometry_struct& geometry, photon_data& photon,
+                    random_dirty& random_obj)
 
 {
-
   double sqr_g = 0.0;
   double cos_alpha = 0.0;
 
   // determine the cosine of the scattering angle
   //   if g is to near zero (isotropic), just randomly determine angle
   //   equations tested to work as long as g > 1e-15  (KDG 28 Dec 2004)
-  if (geometry.g == -2) { // model phase function
+  if (geometry.g == -2) {  // model phase function
     double rannum = random_obj.random_num();
-    uint i1,i2,i3;
+    uint i1, i2, i3;
     i1 = 0;
     i3 = geometry.phi.size();
-    i2 = (i1 + i3)/2;
+    i2 = (i1 + i3) / 2;
     while ((i3 - i1) > 1) {
-      if (rannum > geometry.phi_sum[i2]) i1 = i2; else i3 = i2;
-//       cout << rannum << " ";
-//       cout << geometry.phi[i1] << " " << geometry.phi[i3] << " ";
-//       cout << i1 << " " << i3 << endl;
-      i2 = (i1 + i3)/2;
+      if (rannum > geometry.phi_sum[i2])
+        i1 = i2;
+      else
+        i3 = i2;
+      //       cout << rannum << " ";
+      //       cout << geometry.phi[i1] << " " << geometry.phi[i3] << " ";
+      //       cout << i1 << " " << i3 << endl;
+      i2 = (i1 + i3) / 2;
     }
     cos_alpha = geometry.phi_angle[i1] -
-      ((rannum - geometry.phi_sum[i3])/(geometry.phi_sum[i1] - geometry.phi_sum[i3]))*
-      (geometry.phi_angle[i1] - geometry.phi_angle[i3]);
-//     cout << float(i1)/float(geometry.phi.size()) << " ";
-//     cout << (rannum - geometry.phi_sum[i3])/(geometry.phi_sum[i1] - geometry.phi_sum[i3]) << endl;
-//     cout << "cos_angle = " << cos_alpha << endl;
-//     exit(8);
-//     cout << geometry.phi_angle[i1] << " ";
-//     cout << cos_alpha << " ";
-//     cout << geometry.phi_angle[i3] << endl;
-//     cout.flush();
-  } else if ((geometry.g > ROUNDOFF_ERR_TRIG) && (geometry.scat_angle_bias_fraction > 0.0)) {
-    sqr_g = pow(geometry.g,2);
+                ((rannum - geometry.phi_sum[i3]) /
+                 (geometry.phi_sum[i1] - geometry.phi_sum[i3])) *
+                    (geometry.phi_angle[i1] - geometry.phi_angle[i3]);
+    //     cout << float(i1)/float(geometry.phi.size()) << " ";
+    //     cout << (rannum - geometry.phi_sum[i3])/(geometry.phi_sum[i1] -
+    //     geometry.phi_sum[i3]) << endl; cout << "cos_angle = " << cos_alpha <<
+    //     endl; exit(8); cout << geometry.phi_angle[i1] << " "; cout <<
+    //     cos_alpha << " "; cout << geometry.phi_angle[i3] << endl;
+    //     cout.flush();
+  } else if ((geometry.g > ROUNDOFF_ERR_TRIG) &&
+             (geometry.scat_angle_bias_fraction > 0.0)) {
+    sqr_g = pow(geometry.g, 2);
 
     double ran_num = random_obj.random_num();
     double ran_num2 = random_obj.random_num();
-    if (ran_num >= geometry.scat_angle_bias_fraction) { // sample from HG function
-      cos_alpha = (1.0 + sqr_g) -
-        pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*ran_num2),2);
-      cos_alpha /= (2.0*geometry.g);
-    } else { // sample from isotropic function
-      cos_alpha = 2.0*ran_num2 - 1.0;
+    if (ran_num >=
+        geometry.scat_angle_bias_fraction) {  // sample from HG function
+      cos_alpha =
+          (1.0 + sqr_g) -
+          pow((1.0 - sqr_g) / (1.0 - geometry.g + 2.0 * geometry.g * ran_num2),
+              2);
+      cos_alpha /= (2.0 * geometry.g);
+    } else {  // sample from isotropic function
+      cos_alpha = 2.0 * ran_num2 - 1.0;
     }
 
     // multiplicative weight needed
     double biased_weight_factor = 0.0;
-    biased_weight_factor = (1.0 - geometry.scat_angle_bias_fraction) +
-      (geometry.scat_angle_bias_fraction/
-       ((1 - sqr_g)*pow((1.0 + sqr_g - 2.0*geometry.g*cos_alpha),-1.5)));
+    biased_weight_factor =
+        (1.0 - geometry.scat_angle_bias_fraction) +
+        (geometry.scat_angle_bias_fraction /
+         ((1 - sqr_g) *
+          pow((1.0 + sqr_g - 2.0 * geometry.g * cos_alpha), -1.5)));
 
     // update the scattered weight
     photon.scat_weight /= biased_weight_factor;
@@ -75,22 +81,25 @@ void scatter_photon (geometry_struct& geometry,
     // cout << endl;
 
   } else if (geometry.g > ROUNDOFF_ERR_TRIG) {
-    sqr_g = pow(geometry.g,2);
+    sqr_g = pow(geometry.g, 2);
 
-    cos_alpha = (1.0 + sqr_g) -
-      pow((1.0 - sqr_g)/(1.0 - geometry.g + 2.0*geometry.g*random_obj.random_num()),2);
-    cos_alpha /= (2.0*geometry.g);
+    cos_alpha =
+        (1.0 + sqr_g) -
+        pow((1.0 - sqr_g) /
+                (1.0 - geometry.g + 2.0 * geometry.g * random_obj.random_num()),
+            2);
+    cos_alpha /= (2.0 * geometry.g);
 
   } else
-    cos_alpha = 2.0*random_obj.random_num() - 1.0;
+    cos_alpha = 2.0 * random_obj.random_num() - 1.0;
 
   // calculate sine of scattering angle
-  double sin_alpha = 1.0 - pow(cos_alpha,2);
+  double sin_alpha = 1.0 - pow(cos_alpha, 2);
   if (sin_alpha != 0.0) sin_alpha = sqrt(sin_alpha);
 
   // determine the angle perpendicular to the photon direction
   //   assuming unaligned grains -> random
-  double phi = M_PI*(2.0*random_obj.random_num() - 1.0);
+  double phi = M_PI * (2.0 * random_obj.random_num() - 1.0);
   // get the sine and cosine of this angle
   double cos_phi = cos(phi);
   double sin_phi = sin(phi);
@@ -100,24 +109,28 @@ void scatter_photon (geometry_struct& geometry,
   //   roundoff error good to approx. 1e-16 (checked KDG 28 Dec 2004)
   double new_dir_cosines[3];
   if ((1.0 - fabs(photon.dir_cosines[2])) > ROUNDOFF_ERR_TRIG) {
-    double tmp = sqrt(1.0 - pow(photon.dir_cosines[2],2));
-    new_dir_cosines[0] = sin_alpha*(cos_phi*photon.dir_cosines[2]*photon.dir_cosines[0] -
-			    sin_phi*photon.dir_cosines[1]);
-    new_dir_cosines[0] = (new_dir_cosines[0]/tmp) + cos_alpha*photon.dir_cosines[0];
-    new_dir_cosines[1] = sin_alpha*(cos_phi*photon.dir_cosines[2]*photon.dir_cosines[1] +
-			    sin_phi*photon.dir_cosines[0]);
-    new_dir_cosines[1] = (new_dir_cosines[1]/tmp) + cos_alpha*photon.dir_cosines[1];
-    new_dir_cosines[2] = -sin_alpha*cos_phi*tmp + cos_alpha*photon.dir_cosines[2];
+    double tmp = sqrt(1.0 - pow(photon.dir_cosines[2], 2));
+    new_dir_cosines[0] =
+        sin_alpha * (cos_phi * photon.dir_cosines[2] * photon.dir_cosines[0] -
+                     sin_phi * photon.dir_cosines[1]);
+    new_dir_cosines[0] =
+        (new_dir_cosines[0] / tmp) + cos_alpha * photon.dir_cosines[0];
+    new_dir_cosines[1] =
+        sin_alpha * (cos_phi * photon.dir_cosines[2] * photon.dir_cosines[1] +
+                     sin_phi * photon.dir_cosines[0]);
+    new_dir_cosines[1] =
+        (new_dir_cosines[1] / tmp) + cos_alpha * photon.dir_cosines[1];
+    new_dir_cosines[2] =
+        -sin_alpha * cos_phi * tmp + cos_alpha * photon.dir_cosines[2];
   } else {
-    new_dir_cosines[0] = sin_alpha*cos_phi;
-    new_dir_cosines[1] = sin_alpha*sin_phi;
-    new_dir_cosines[2] = cos_alpha*photon.dir_cosines[2];
+    new_dir_cosines[0] = sin_alpha * cos_phi;
+    new_dir_cosines[1] = sin_alpha * sin_phi;
+    new_dir_cosines[2] = cos_alpha * photon.dir_cosines[2];
   }
 
   // update the direction cosines of the photon
   int i;
-  for (i = 0; i < 3; i++)
-    photon.dir_cosines[i] = new_dir_cosines[i];
+  for (i = 0; i < 3; i++) photon.dir_cosines[i] = new_dir_cosines[i];
 
 #ifdef DEBUG_SP
   cout << "# scat = " << photon.num_scat << endl;
@@ -127,9 +140,10 @@ void scatter_photon (geometry_struct& geometry,
   // update the scattered weight
   photon.scat_weight *= geometry.albedo;
 
-  // updated to include the weight reduction due to continuous absorption - KDG 17 jun 15
-  // does not seem to work - KDG 17 jun 15
-  //photon.scat_weight *= geometry.albedo*(1.0 - exp(-1.0*photon.prev_tau_surface));
+  // updated to include the weight reduction due to continuous absorption - KDG
+  // 17 jun 15 does not seem to work - KDG 17 jun 15
+  // photon.scat_weight *= geometry.albedo*(1.0 -
+  // exp(-1.0*photon.prev_tau_surface));
 
   // update the number of scatterings
   photon.num_scat++;
@@ -140,14 +154,16 @@ void scatter_photon (geometry_struct& geometry,
   {
     // find path_tau[]
     photon_data dummy_photon = photon;
-    dummy_photon.current_grid_num = 0;  // set to the base grid to start tarjectory correctly
-    dummy_photon.path_cur_cells = 0; // set to 0 to save cells traversed
+    dummy_photon.current_grid_num =
+        0;  // set to the base grid to start trajectory correctly
+    dummy_photon.path_cur_cells = 0;  // set to 0 to save cells traversed
 
     double target_tau = 1e20;
-    double target_dist = 1e10*geometry.radius;
+    double target_dist = 1e10 * geometry.radius;
     int escape = 0;
     double tau_to_surface = 0.0;
-    calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist, escape, tau_to_surface);
+    calc_photon_trajectory(dummy_photon, geometry, target_tau, target_dist,
+                           escape, tau_to_surface, 0);
 
     photon.prev_tau_surface = tau_to_surface;
 
@@ -158,7 +174,8 @@ void scatter_photon (geometry_struct& geometry,
      * prob_entering/prob_leaving:
      *   probability that the photon packet enters/leaves the grid cell
      */
-    const double abs_weight_init = (1. - geometry.albedo)*dummy_photon.scat_weight;
+    const double abs_weight_init =
+        (1. - geometry.albedo) * dummy_photon.scat_weight;
 
     double tau_entering = 0.;
     double prob_entering = 1.;
@@ -175,7 +192,7 @@ void scatter_photon (geometry_struct& geometry,
       // find the absorbed weight
       tau_leaving = tau_entering + dummy_photon.path_tau[i];
       prob_leaving = exp(-tau_leaving);
-      abs_weight = abs_weight_init*(prob_entering - prob_leaving);
+      abs_weight = abs_weight_init * (prob_entering - prob_leaving);
 
 #ifdef DEBUG_SP
       cout << i << " ";
@@ -189,20 +206,27 @@ void scatter_photon (geometry_struct& geometry,
 #endif
 
       // deposit the energy
-      grid_cell& this_cell = geometry.grids[dummy_photon.path_pos_index[0][i]].grid(dummy_photon.path_pos_index[1][i],dummy_photon.path_pos_index[2][i],dummy_photon.path_pos_index[3][i]);
+      grid_cell& this_cell =
+          geometry.grids[dummy_photon.path_pos_index[0][i]].grid(
+              dummy_photon.path_pos_index[1][i],
+              dummy_photon.path_pos_index[2][i],
+              dummy_photon.path_pos_index[3][i]);
       this_cell.absorbed_energy[geometry.abs_energy_wave_index] += abs_weight;
       if (this_cell.last_photon_number != photon.number) {
         this_cell.absorbed_energy_num_photons[geometry.abs_energy_wave_index]++;
-        this_cell.absorbed_energy_x2[geometry.abs_energy_wave_index] += abs_weight*abs_weight;
+        this_cell.absorbed_energy_x2[geometry.abs_energy_wave_index] +=
+            abs_weight * abs_weight;
         this_cell.last_photon_number = photon.number;
         this_cell.last_photon_absorbed_energy = abs_weight;
       } else {
-        // compute the difference in x2 values previously added to what should be added
-        // avoids having to save this information separately and then have a special step at the end to add the total photon's contribution
-      float prev_x2 = pow(this_cell.last_photon_absorbed_energy, 2.0);
-      this_cell.last_photon_absorbed_energy += abs_weight;
-      // add the difference = just like adding the correct x2
-      this_cell.absorbed_energy_x2[geometry.abs_energy_wave_index] += pow(this_cell.last_photon_absorbed_energy, 2.0) - prev_x2;
+        // compute the difference in x2 values previously added to what should
+        // be added avoids having to save this information separately and then
+        // have a special step at the end to add the total photon's contribution
+        float prev_x2 = pow(this_cell.last_photon_absorbed_energy, 2.0);
+        this_cell.last_photon_absorbed_energy += abs_weight;
+        // add the difference = just like adding the correct x2
+        this_cell.absorbed_energy_x2[geometry.abs_energy_wave_index] +=
+            pow(this_cell.last_photon_absorbed_energy, 2.0) - prev_x2;
       }
 
       // move to the next grid cell
@@ -211,10 +235,9 @@ void scatter_photon (geometry_struct& geometry,
     }
 
 #ifdef DEBUG_SP
-  cout << abs_weight_init << " ";
-  cout << tot_abs_temp << endl;
-  if (photon.target_tau > 0.5) exit(8);
+    cout << abs_weight_init << " ";
+    cout << tot_abs_temp << endl;
+    if (photon.target_tau > 0.5) exit(8);
 #endif
-
   }
 }

--- a/DIRTY/scattered_weight_towards_observer.cpp
+++ b/DIRTY/scattered_weight_towards_observer.cpp
@@ -83,7 +83,7 @@ double scattered_weight_towards_observer(photon_data photon,
 #endif
   try {
     distance_traveled = calc_photon_trajectory(
-        photon, geometry, target_tau, target_dist, escape, tau_scat_to_obs);
+        photon, geometry, target_tau, target_dist, escape, tau_scat_to_obs, 0);
   } catch (std::out_of_range) {
     cout << "photon # = " << photon.number << endl;
     cout << "num scat = " << photon.num_scat << endl;

--- a/DIRTY/stellar_weight_towards_observer.cpp
+++ b/DIRTY/stellar_weight_towards_observer.cpp
@@ -97,7 +97,7 @@ double stellar_weight_towards_observer(photon_data photon,
 
   double distance_traveled = 0.0;
   distance_traveled = calc_photon_trajectory(
-      photon, geometry, target_tau, target_dist, escape, tau_birth_to_obs);
+      photon, geometry, target_tau, target_dist, escape, tau_birth_to_obs, 0);
 
 #ifdef DEBUG_STWTO
   if (photon.number == OUTNUM) {

--- a/docs/pfile_run.rst
+++ b/docs/pfile_run.rst
@@ -37,6 +37,23 @@ generator will use the seed to produce random numbers that are used in various
 parts of Monte Carlo simulation. The independence of runs with different random 
 number seeds is not guaranteed.
 
+**repeat_boundary_xy [0,1]**
+
+This adds a repeating boundary condition for photons that exit the model grid in
+the x or y directions. These photons continue along their trajectories, just
+shifted to the opposite side of the model (i.e., if exiting in the positive x
+direction, the photon's x position is set to -x and the photon continues through
+the model grid).
+
+This option only will work correctly for models that fully fill the main grid -
+no cells with -0.5 indicating the edge of the model has been reached. The slab
+geometry meets this criteria. The file geometry can meet this criteria if the
+file is setup with no -0.5 values.
+
+The repeating xy boundary will cause longer run times as the photon trajectories
+are longer. These run times can be much longer depending on the optical depths
+of the model, where low may mean longer than high, depending on the geometry.
+
 Output Details
 ==============
 


### PR DESCRIPTION
This add the option to have a repeating boundary condition for photons that would normally exit in the x or y directions.  The option is in the "Run" section of the parameter file (i.e., add the line "repeat_boundary_xy=1").  This option only will work correctly for models that fully fill the main grid - no cells with -0.5 indicating the edge of the model has been reached.   The slab geometry meets this criteria.   The file geometry can meet this criteria if the file is setup with no -0.5 values.

The repeating xy boundary will cause longer run times as the photon trajectories are longer.  These run times can be *much* longer depending on the optical depths of the model.  And low may mean longer than high, depending on the geometry. 

Closes #38.